### PR TITLE
On Linux, install basic build requirements for desktop applications.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,12 @@ async function run() {
       await exec.exec("brew install p7zip")
     }
 
+    // Qt installer assumes basic requirements that are not installed by
+    // default on Ubuntu.
+    if (process.platform == "linux") {
+      await exec.exec("sudo apt-get install build-essential libgl1-mesa-dev -y")
+    }
+
     await exec.exec("pip3 install setuptools wheel");
     await exec.exec("pip3 install \"aqtinstall==0.5.*\"");
 


### PR DESCRIPTION
This pull request updates `main.ts` to use the Qt recommended command to install the additional requirements for Linux.

Related to #3, I think the basic build requirements should be installed by the action. According to [Qt's documentation, the Qt installer assumes](https://doc.qt.io/qt-5/linux.html#requirements-for-development-host):

> that a C++ compiler, debugger, make, and other development tools are provided by the host operating system. In addition, building graphical Qt applications requires OpenGL libraries and headers installed

Having the `install-qt-action` perform this installation means end-developers using this action don't need to account for it in their workflow (which makes matrix building a little less complicated as these additional requirements for Linux don't apply to Windows / macOS builds).