### PR TITLE
Use pip --pre and support for Qt modules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Test Installing Qt
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Possible values: `windows`, `mac`, or `linux`
 
 Defaults to the current platform it is being run on.
 
-
 ### `target`
 This is the target platform that you will be building for. You will want to set this if you are building for iOS or Android. 
 
@@ -64,6 +63,9 @@ Default: `${RUNNER_WORKSPACE}` (this is one folder above the starting directory)
 Whether or not to automatically install Qt dependencies on Linux (you probably want to leave this on).
 
 Default: `true`
+
+### `module`
+Additional Qt modules can be added via, e.g., `--module qtcharts`.
 
 ## More info
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,13 +17,14 @@ async function run() {
     }
 
     await exec.exec("pip3 install setuptools wheel");
-    await exec.exec("pip3 install \"aqtinstall==0.5.*\"");
+    await exec.exec("pip3 install aqtinstall --pre");
 
     const dir = (core.getInput("dir") || process.env.RUNNER_WORKSPACE) + "/Qt";
     const version = core.getInput("version");
     let host = core.getInput("host");
     let target = core.getInput("target");
     let arch = core.getInput("arch");
+    let module = core.getInput("module");
 
     //set host automatically if omitted
     if (!host) {
@@ -56,6 +57,9 @@ async function run() {
     let args = ["-O", `${dir}`, `${version}`, `${host}`, `${target}`];
     if (arch) {
       args.push(`${arch}`);
+    }
+    if (module) {
+      args.push(`--module ${module}`);
     }
 
     //accomodate for differences in python 3 executable name


### PR DESCRIPTION
This PR adds support for aqtisntaller module input. This is a new feature since version 0.6a1, see miurahr/aqtinstall#68. 

Also, added the pip --pre flag to get the current pre-release version of aqtinstaller (0.6a2), which introduces a bug fix for the the issue mentioned in #6 and also the qt module support.

Not sure if it works with multiple module inputs such as `-m qtcharts qtnetworkauth`.

Changed the test to include the module flag and to be also triggered by incoming PRs.

Not sure if my code works :) Please let me know what you think.