### PR TITLE
Support cache & Use arch for windows and android only & Customizable aqt version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install Qt
         uses: ./
         with:
+          aqtversion: "==0.7.1"
           modules: qtcharts qtwebengine
 
       - name: Configure test project on windows

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ It can be used with [actions/cache](https://github.com/actions/cache), for examp
 
 ### `aqtversion`
 
-Version of [aqtinstall](https://github.com/miurahr/aqtinstall), in the form used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.x`.
+Version of [aqtinstall](https://github.com/miurahr/aqtinstall), in the form used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`.
 
 ## More info
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,28 @@ Possible values: `qtcharts`, `qtdatavis3d`, `qtpurchasing`, `qtvirtualkeyboard`,
 
 Default: none
 
+### `cached`
+If it is set to `true`, then Qt won't be downloaded, but the environment variables will be set, and essential build tools will be installed.
+
+It can be used with [actions/cache](https://github.com/actions/cache), for example:
+
+```
+- name: Cache Qt
+  id: cache-qt
+  uses: actions/cache@v1
+  with:
+    path: ../Qt
+    key: QtCache
+
+- name: Install Qt
+  uses: jurplel/install-qt-action@v2
+  with:
+    cached: ${{ steps.cache-qt.outputs.cache-hit }}
+```
+
+### `aqtversion`
+
+Version of [aqtinstall](https://github.com/miurahr/aqtinstall), in the form used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.x`.
 
 ## More info
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function run() {
       }
 
       await exec.exec("pip3 install setuptools wheel");
-      await exec.exec("pip3 install \"aqtinstall==0.7.1\"");
+      await exec.exec("pip3 install \"aqtinstall" + (core.getInput("aqtversion") || "==0.7.x") + "\"");
       let host = core.getInput("host");
       let target = core.getInput("target");
       let arch = core.getInput("arch");

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,7 +57,7 @@ async function run() {
 
       //set args
       let args = ["-O", `${dir}`, `${version}`, `${host}`, `${target}`];
-      if (arch) {
+      if (arch && (host == "windows" || host == "android")) {
         args.push(`${arch}`);
       }
       if (modules) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,10 +5,8 @@ import * as exec from '@actions/exec';
 
 async function run() {
   try {
-    // 7-zip is required, and not included on macOS
-    if (process.platform == "darwin") {
-      await exec.exec("brew install p7zip")
-    }
+    const dir = (core.getInput("dir") || process.env.RUNNER_WORKSPACE) + "/Qt";
+    const version = core.getInput("version");
 
     // Qt installer assumes basic requirements that are not installed by
     // default on Ubuntu.
@@ -17,63 +15,67 @@ async function run() {
       await exec.exec("sudo apt-get install build-essential libgl1-mesa-dev -y")
     }
 
-    await exec.exec("pip3 install setuptools wheel");
-    await exec.exec("pip3 install \"aqtinstall==0.7.*\"");
+    if (core.getInput("cached") != "true") {
+      // 7-zip is required, and not included on macOS
+      if (process.platform == "darwin") {
+        await exec.exec("brew install p7zip")
+      }
 
-    const dir = (core.getInput("dir") || process.env.RUNNER_WORKSPACE) + "/Qt";
-    const version = core.getInput("version");
-    let host = core.getInput("host");
-    let target = core.getInput("target");
-    let arch = core.getInput("arch");
-    let modules = core.getInput("modules").split(" ");
+      await exec.exec("pip3 install setuptools wheel");
+      await exec.exec("pip3 install \"aqtinstall==0.7.1\"");
+      let host = core.getInput("host");
+      let target = core.getInput("target");
+      let arch = core.getInput("arch");
+      let modules = core.getInput("modules").split(" ");
 
-    //set host automatically if omitted
-    if (!host) {
-      switch(process.platform) {
-        case "win32": {
-            host = "windows";
-            break;
-        }
-        case "darwin": {
-            host = "mac";
-            break;
-        }
-        default: {
-            host = "linux";
-            break;
+      //set host automatically if omitted
+      if (!host) {
+        switch(process.platform) {
+          case "win32": {
+              host = "windows";
+              break;
+          }
+          case "darwin": {
+              host = "mac";
+              break;
+          }
+          default: {
+              host = "linux";
+              break;
+          }
         }
       }
-    }
 
-    //set arch automatically if omitted
-    if (!arch) {
-      if (host == "windows") {
-        arch = "win64_msvc2017_64";
-      } else if (host == "android") {
-        arch = "android_armv7";
+      //set arch automatically if omitted
+      if (!arch) {
+        if (host == "windows") {
+          arch = "win64_msvc2017_64";
+        } else if (host == "android") {
+          arch = "android_armv7";
+        }
       }
-    }
 
-    //set args
-    let args = ["-O", `${dir}`, `${version}`, `${host}`, `${target}`];
-    if (arch) {
-      args.push(`${arch}`);
-    }
-    if (modules) {
-      args.push("-m");
-      modules.forEach(function(currentValue) {
-        args.push(currentValue);
-      });
-    }
+      //set args
+      let args = ["-O", `${dir}`, `${version}`, `${host}`, `${target}`];
+      if (arch) {
+        args.push(`${arch}`);
+      }
+      if (modules) {
+        args.push("-m");
+        modules.forEach(function(currentValue) {
+          args.push(currentValue);
+        });
+      }
 
-    //accomodate for differences in python 3 executable name
-    let pythonName = "python3";
-    if (process.platform == "win32") {
-      pythonName = "python";
-    }
+      //accomodate for differences in python 3 executable name
+      let pythonName = "python3";
+      if (process.platform == "win32") {
+        pythonName = "python";
+      }
 
-    //run aqtinstall with args
-    await exec.exec(`${pythonName} -m aqt install`, args);
+      //run aqtinstall with args
+      await exec.exec(`${pythonName} -m aqt install`, args);
+    }
 
     //set environment variables
     let qtPath = dir + "/" + version;
@@ -81,7 +83,6 @@ async function run() {
 
     core.exportVariable('Qt5_Dir', qtPath);
     core.addPath(qtPath + "/bin");
-    
   } catch (error) {
     core.setFailed(error.message);
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,7 +22,7 @@ async function run() {
       }
 
       await exec.exec("pip3 install setuptools wheel");
-      await exec.exec("pip3 install \"aqtinstall" + (core.getInput("aqtversion") || "==0.7.x") + "\"");
+      await exec.exec("pip3 install \"aqtinstall" + (core.getInput("aqtversion") || "==0.7.*") + "\"");
       let host = core.getInput("host");
       let target = core.getInput("target");
       let arch = core.getInput("arch");


### PR DESCRIPTION
Support cache, close #22.

Example of using cache:

```yaml
- name: Cache Qt
  id: cache-qt
  uses: actions/cache@v1
  with:
    path: ../Qt
    key: QtCache

- name: Install Qt
  uses: repo/install-qt-action@version
  with:
    cached: ${{ steps.cache-qt.outputs.cache-hit }}
```

---

Use arch for windows and android only, fixes #25.

---

Customizable aqtinstall version, solves problems like #27.