### PR TITLE
add libxkbcommon-x11-0 to linux deps

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ async function run() {
       // default on Ubuntu.
       if (process.platform == "linux" && core.getInput("install-deps") == "true") {
         await exec.exec("sudo apt-get update")
-        await exec.exec("sudo apt-get install build-essential libgl1-mesa-dev -y")
+        await exec.exec("sudo apt-get install build-essential libgl1-mesa-dev libxkbcommon-x11-0 -y")
       }
 
       if (core.getInput("cached") != "true") {


### PR DESCRIPTION
I'm using your action in our pipeline and faced an issue (very similar to https://github.com/microsoft/azure-pipelines-image-generation/issues/897)

The problem I've faced is that binaries on linux machine to which I've installed QT by their official installer worked fine but binaries from CI pipeline (16-04 worker) doesn't start on linux with:

```
qt.qpa.plugin: Could not find the Qt platform plugin "xcb" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Aborted (core dumped)
```

So I've relaised that https://github.com/probonopd/linuxdeployqt we using for deploy doesn't attach plugins by some reason

I've started to dig and in CI build logs (https://github.com/KomodoPlatform/atomicDEX-Pro/actions/runs/120505341) found why:

```
2020-05-31T10:42:15.9344441Z ERROR: ldd outputLine: "libxkbcommon-x11.so.0 => not found"
2020-05-31T10:42:15.9345352Z ERROR: for binary: "/home/runner/work/atomicDEX-Pro/atomicDEX-Pro/Qt/5.14.2/gcc_64/plugins/platforms/libqxcb.so"
2020-05-31T10:42:15.9345848Z ERROR: Please ensure that all libraries can be found by ldd. Aborting.
```

after short dig I've also found out that that package `libxkbcommon-x11.so.0` installing automagically by QT installer (.run from here https://wiki.qt.io/Install_Qt_5_on_Ubuntu) and doesn't presists by default in 16-04 azure image

so I think this dep there might save some time and some walls from head smacking :)