### PR TITLE
migrate from semver to compare-versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,10 +92,10 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "semver": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+    "compare-versions": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "typescript": {
       "version": "3.5.3",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@actions/core": "^1.0.0",
     "@actions/exec": "^1.0.0",
     "glob": "^7.0.0",
-    "semver": "^7.3.2"
+    "compare-versions": "^3.6.0"
   },
   "devDependencies": {
     "@types/node": "^12.0.4",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,6 +1,6 @@
 import * as process from "process";
 import * as glob from "glob";
-import * as semver from "semver";
+import * as compareVersions from "compare-versions";
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 
@@ -54,7 +54,7 @@ async function run() {
         if (!arch) {
           if (host == "windows") {
             arch = "win64_msvc2017_64";
-            if (semver.gte(version, '5.15.0')) { // if version is greater than or equal to 5.15.0
+            if (compareVersions.compare(version, '5.15.0', '>=')) { // if version is greater than or equal to 5.15.0
               arch = "win64_msvc2019_64";
             }
           } else if (host == "android") {


### PR DESCRIPTION
this might help to fix issue #43
compare-versions supports incomplete version numbers like 5.5 (instead of 5.5.1)

Attention, as I have no clue about the scripting languages you use here: please carefully review my suggested changes!