### PR TITLE
Always call pip via python -m pip

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -22,9 +22,15 @@ async function run() {
           await exec.exec("brew install p7zip")
         }
 
-        await exec.exec("pip3 install setuptools wheel");
-        await exec.exec("pip3 install \"py7zr" + core.getInput("py7zrversion") + "\"");
-        await exec.exec("pip3 install \"aqtinstall" + core.getInput("aqtversion") + "\"");
+        //accomodate for differences in python 3 executable name
+        let pythonName = "python3";
+        if (process.platform == "win32") {
+          pythonName = "python";
+        }
+
+        await exec.exec(pythonName + " -m pip install setuptools wheel");
+        await exec.exec(pythonName + " -m pip install \"py7zr" + core.getInput("py7zrversion") + "\"");
+        await exec.exec(pythonName + " -m pip install \"aqtinstall" + core.getInput("aqtversion") + "\"");
         let host = core.getInput("host");
         const target = core.getInput("target");
         let arch = core.getInput("arch");
@@ -86,12 +92,6 @@ async function run() {
           modules.split(" ").forEach(function(currentModule) {
             args.push(currentModule);
           });
-        }
-
-        //accomodate for differences in python 3 executable name
-        let pythonName = "python3";
-        if (process.platform == "win32") {
-          pythonName = "python";
         }
 
         //run aqtinstall with args


### PR DESCRIPTION
This makes sure that "pip3 install" and "python3" refer to the same python version.
Supposed to fix #60.