### PR TITLE
Fix separator in LD_LIBRARY_PATH

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -125,7 +125,7 @@ async function run() {
         }
         if (process.platform == "linux") {
             if (process.env.LD_LIBRARY_PATH) {
-                core.exportVariable('LD_LIBRARY_PATH', process.env.LD_LIBRARY_PATH + ";" + qtPath + "/lib");
+                core.exportVariable('LD_LIBRARY_PATH', process.env.LD_LIBRARY_PATH + ":" + qtPath + "/lib");
             } else {
                 core.exportVariable('LD_LIBRARY_PATH', qtPath + "/lib");
             }


### PR DESCRIPTION
':' is the correct separator, not ';'

The 2.12 of this action broke our CI because of malformed LD_LIBRARY_PATH