### PR TITLE
CI (GitHub Actions): try actions/checkout@v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
         os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, windows-2019, macos-10.15]
         version: ['5.9.0', '5.15.1']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
It seems that actions/checkout@v1 is buggy when checking out from PRs. Let's try v2.

https://github.com/jurplel/install-qt-action/runs/3704315556?check_suite_focus=true

```console
> Run actions/checkout@v1
Syncing repository: jurplel/install-qt-action
git version
git version 2.33.0.windows.2
git lfs version
git-lfs/2.13.3 (GitHub; windows amd64; go 1.16.2; git a5e65851)
git init "D:\a\install-qt-action\install-qt-action"
Initialized empty Git repository in D:/a/install-qt-action/install-qt-action/.git/
git remote add origin https://github.com/jurplel/install-qt-action
git config gc.auto 0
git config --get-all http.https://github.com/jurplel/install-qt-action.extraheader
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --tags --prune --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/pull/109/merge:refs/remotes/pull/109/merge
Error: fatal: couldn't find remote ref refs/pull/109/merge
Warning: Git fetch failed with exit code 128, back off 3.99 seconds before retry.
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --tags --prune --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/pull/109/merge:refs/remotes/pull/109/merge
Error: fatal: couldn't find remote ref refs/pull/109/merge
Warning: Git fetch failed with exit code 128, back off 7.342 seconds before retry.
git -c http.extraheader="AUTHORIZATION: basic ***" fetch --tags --prune --progress --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/pull/109/merge:refs/remotes/pull/109/merge
Error: fatal: couldn't find remote ref refs/pull/109/merge
Error: Git fetch failed with exit code: 128
Error: Exit code 1 returned from process: file name 'c:\runners\2.283.1\bin\Runner.PluginHost.exe', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```