### PR TITLE
CI (GitHub Actions): drop the Ubuntu 16.04 environment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, ubuntu-18.04, windows-2019, macos-10.15]
         version: ['5.9.0', '5.15.1']
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
See:

- actions/virtual-environments#3287
- [GitHub Actions : Ubuntu 16.04 LTS virtual environment will be removed on September 20, 2021 | GitHub Changelog](https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/).
