### PR TITLE
Use aqtinstall v2.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           modules: 'qtwebengine'
           version: ${{ matrix.version }}
-          tools: 'tools_ifw,4.1.1,qt.tools.ifw.41 tools_qtcreator,5.0.1-0,qt.tools.qtcreator'
+          tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
 
       - name: Configure test project on windows
         if: startsWith(matrix.os, 'windows')

--- a/README.md
+++ b/README.md
@@ -111,9 +111,13 @@ Default: `true`
 ### `tools`
 
 Qt "tools" to be installed. I would recommend looking at [aqtinstall](https://github.com/miurahr/aqtinstall)'s instructions for this, as it is an experimental feature.
-Specify the tool name, tool version, and arch separated by commas, and separate multiple tools with spaces.
+Specify the tool name and tool variant name separated by commas, and separate multiple tools with spaces.
+If you wish to install all tools available for a given tool name, you can leave off the tool variant name.
 
-Example value: 'tools_ifw,4.0.0,qt.tools.ifw.40 tools_qtcreator,4.13.2-0,qt.tools.qtcreator'
+For example, this value will install the most recent versions of QtIFW and QtCreator: 
+```
+    tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
+```
 
 ### `set-env`
 Set this to false if you want to avoid setting environment variables for whatever reason.
@@ -130,7 +134,7 @@ Default: `false`
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `==1.2.5`
+Default: `==2.0.0`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
@@ -157,10 +161,10 @@ Example value: `--external 7z`
         modules: 'qtcharts qtwebengine'
         cached: 'false'
         setup-python: 'true'
-        tools: 'tools_ifw,4.1.1,qt.tools.ifw.41 tools_qtcreator,5.0.1-0,qt.tools.qtcreator'
+        tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'false'
         tools-only: 'false'
-        aqtversion: '==1.2.5'
+        aqtversion: '==2.0.0'
         py7zrversion: '==0.16.1'
         extra: '--external 7z'
 ```

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ inputs:
     default: 'false'
   aqtversion:
     description: "Version of aqtinstall to use in case of issues"
-    default: '==1.2.5'
+    default: '==2.0.0'
   py7zrversion:
     description: "Version of py7zr to use in case of issues"
     default: '==0.16.1'

--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,7 @@ async function run() {
         }
 
         //set args
-        let args = [`${version}`, `${host}`, `${target}`];
+        let args = [`${host}`, `${target}`, `${version}`];
         if (arch && ((host == "windows" || target == "android") || arch == "wasm_32")) {
           args.push(`${arch}`);
         }
@@ -113,12 +113,14 @@ async function run() {
 
         //run aqtinstall with args, and install tools if requested
         if (core.getInput("tools-only") != "true") {
-          await exec.exec(`${pythonName} -m aqt install`, args);
+          await exec.exec(`${pythonName} -m aqt install-qt`, args);
         }
         if (tools) {
           tools.split(" ").forEach(async element => {
-            let elements = element.split(",");
-            await exec.exec(`${pythonName} -m aqt tool ${host} ${elements[0]} ${elements[1]} ${elements[2]}`, extraArgs);
+            const elements = element.split(",");
+            const toolName = elements[0];
+            const variantName = elements.length > 1 ? elements[elements.length - 1] : "";
+            await exec.exec(`${pythonName} -m aqt install-tool ${host} ${target} ${toolName} ${variantName}`, extraArgs);
           });
         }
       }


### PR DESCRIPTION
This is my attempt at updating the action to use the 2.0.0 release of `aqtinstall`.

Fix #114. `aqt` v2.0.0 allows you to install tools without specifying a tool version number, so the syntax of the `tool` field is changed. I made an effort to maintain backwards compatibility though, so this PR will simply ignore the version number if you put it in:

```yml
    tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'                                # new syntax
    tools: 'tools_ifw,4.1.1,qt.tools.ifw.41 tools_qtcreator,5.0.1-0,qt.tools.qtcreator'  # still works
```

This is also a step towards fixing #98. `aqt` 2.0.0 allows you to use a SimpleSpec to specify a Qt version; to install the latest 5.12 you would use `aqt install-qt windows desktop 5.12 <arch>`.

**Please note:** aqtinstall 2.0.0 introduces breaking changes to the interface of aqt, and with this PR applied, it will no longer be possible to use earlier versions of aqt. If you think it's worth it to continue to support older versions of aqt, I can modify this to make that possible.