### PR TITLE
Add Qt 6.2 to test suite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,18 +48,22 @@ jobs:
 
       - name: Configure test project on windows
         if: startsWith(matrix.os, 'windows')
+        env:
+          QT_VERSION: ${{ matrix.version }}
         run: |
           cd tests/TestWithModules
           call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          IF exist %Qt5_DIR%/lib/cmake ( dir %Qt5_DIR%/lib/cmake ) ELSE ( dir %Qt6_DIR%/lib/cmake )
+          IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR%/lib/cmake ) ELSE ( dir %Qt6_DIR%/lib/cmake )
           qmake
         shell: cmd
 
       - name: Configure test project on unix
         if: (!startsWith(matrix.os, 'windows'))
+        env:
+          QT_VERSION: ${{ matrix.version }}
         run: |
           cd tests/TestWithModules
-          if [ -d "$Qt6_DIR/lib/cmake" ]; then
+          if [[ $QT_VERSION == 6* ]]; then
             ls "$Qt6_DIR/lib/cmake"
           else
             ls "$Qt5_DIR/lib/cmake"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           cd tests/TestWithModules
           call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR%/lib/cmake ) ELSE ( dir %Qt6_DIR%/lib/cmake )
+          IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR%\lib\cmake ) ELSE ( dir %Qt6_DIR%\lib\cmake )
           qmake
         shell: cmd
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-18.04, windows-2019, macos-10.15]
-        version: ['5.9.0', '5.15.1']
+        version: ['5.9.0', '5.15.1', '6.2.0']
+
+        # Ubuntu 18 is not a supported target for Qt 6: https://www.qt.io/blog/qt6-development-hosts-and-targets
+        exclude:
+          - os: ubuntu-18.04
+            version: '6.2.0'
     steps:
       - uses: actions/checkout@v2
 
@@ -24,10 +29,20 @@ jobs:
           npm run build-setup-python
           npm run build
 
-      - name: Install Qt with options
+      - name: Install Qt5 with options
+        if: startsWith(matrix.version, '5')
         uses: ./
         with:
           modules: 'qtwebengine'
+          version: ${{ matrix.version }}
+          tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
+
+      - name: Install Qt6 with options
+        if: startsWith(matrix.version, '6.2')
+        uses: ./
+        with:
+          # In Qt 6.2.0, qtwebengine requires qtpositioning and qtwebchannel
+          modules: 'qtwebengine qtpositioning qtwebchannel'
           version: ${{ matrix.version }}
           tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
 
@@ -36,14 +51,19 @@ jobs:
         run: |
           cd tests/TestWithModules
           call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          dir %Qt5_DIR%/lib/cmake
+          IF exist %Qt5_DIR%/lib/cmake ( dir %Qt5_DIR%/lib/cmake ) ELSE ( dir %Qt6_DIR%/lib/cmake )
           qmake
         shell: cmd
-          
+
       - name: Configure test project on unix
         if: (!startsWith(matrix.os, 'windows'))
         run: |
           cd tests/TestWithModules
-          ls $Qt5_DIR/lib/cmake
+          if [ -d "$Qt6_DIR/lib/cmake" ]; then
+            ls "$Qt6_DIR/lib/cmake"
+          else
+            ls "$Qt5_DIR/lib/cmake"
+          fi
           qmake
         shell: bash
+

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ The desired version of Qt to install.
 
 Default: `5.15.2` (Latest LTS at the time of writing)
 
+**Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
+
 ### `host`
 This is the host platform of the Qt version you will be installing. It's unlikely that you will need to set this manually if you are just building.
 

--- a/tests/TestWithModules/TestWithModules.pro
+++ b/tests/TestWithModules/TestWithModules.pro
@@ -1,5 +1,5 @@
 QT -= gui
-QT += webengine
+QT += webenginewidgets
 
 CONFIG += c++11 console
 CONFIG -= app_bundle


### PR DESCRIPTION
This adds Qt 6.2.0 to the test workflow.

I am using #119 as a base for this because I am not certain that aqt 1.2.5 installs modules properly. I think v1.2.5 can install the `qtwebengine` module if you call it `addons.qtwebengine`, but that solution is not so nice. With aqt v2 you can just call it `qtwebengine`.

I have observed that when you run `qmake` on a project that requests the `webengine` module, it doesn't work on Qt 6, no matter what modules are installed. I believe that the solution is to use `webenginewidgets` or `webenginecore` in the test `.pro` file. See [Qt WebEngine Examples](https://doc.qt.io/qt-6.2/webengine-widgetexamples.html) and a [specific example](https://code.qt.io/cgit/qt/qtwebengine.git/tree/examples/webenginewidgets/contentmanipulation/CMakeLists.txt). Accordingly, I have modified `tests/TestWithModules/TestWithModules.pro`. I have also observed that the configuration step fails when you use the `qtwebengine` module without having `qtpositioning` and `qtwebchannel` installed, so I have conditionally added them to `.github/workflows/test.yml`.

I have excluded Qt 6.2.0 from the Ubuntu 18.04 builds, thanks to https://github.com/jurplel/install-qt-action/issues/95#issuecomment-939599149.

I think that this fixes #95. Perhaps a note should be added to README.MD, stating that Ubuntu 20.04+ is required for Qt 6+?