### PR TITLE
Fix directory separators in environment variables on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           cd tests/TestWithModules
           call "%programfiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          dir %Qt5_DIR%/lib/cmake
+          dir %Qt5_DIR%\lib\cmake
           qmake
         shell: cmd
           

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,9 @@ import * as compareVersions from "compare-versions";
 import * as core from '@actions/core';
 import * as exec from '@actions/exec';
 import * as setupPython from 'setup-python/lib/find-python'
+import path from 'path';
+
+const nativePath = process.platform === "win32" ? path.win32.normalize : path.normalize;
 
 async function run() {
     try {
@@ -131,23 +134,23 @@ async function run() {
       }
       
       let qtPath = dir + "/" + version;
-      qtPath = glob.sync(qtPath + '/**/*')[0];
+      qtPath = nativePath(glob.sync(qtPath + '/**/*')[0]);
       if (setEnv == "true") {
         if (tools) {
-            core.exportVariable('IQTA_TOOLS', dir + "/Tools");
+            core.exportVariable('IQTA_TOOLS', nativePath(dir + "/Tools"));
         }
         if (process.platform == "linux") {
             if (process.env.LD_LIBRARY_PATH) {
-                core.exportVariable('LD_LIBRARY_PATH', process.env.LD_LIBRARY_PATH + ":" + qtPath + "/lib");
+                core.exportVariable('LD_LIBRARY_PATH', nativePath(process.env.LD_LIBRARY_PATH + ":" + qtPath + "/lib"));
             } else {
-                core.exportVariable('LD_LIBRARY_PATH', qtPath + "/lib");
+                core.exportVariable('LD_LIBRARY_PATH', nativePath(qtPath + "/lib"));
             }
         }
         if (process.platform != "win32") {
           if (process.env.PKG_CONFIG_PATH) {
-              core.exportVariable('PKG_CONFIG_PATH', process.env.PKG_CONFIG_PATH + ":" + qtPath + "/lib/pkgconfig");
+              core.exportVariable('PKG_CONFIG_PATH', nativePath(process.env.PKG_CONFIG_PATH + ":" + qtPath + "/lib/pkgconfig"));
           } else {
-              core.exportVariable('PKG_CONFIG_PATH', qtPath + "/lib/pkgconfig");
+              core.exportVariable('PKG_CONFIG_PATH', nativePath(qtPath + "/lib/pkgconfig"));
           }
       }
         // If less than qt6, set qt5_dir variable, otherwise set qt6_dir variable
@@ -157,9 +160,9 @@ async function run() {
         } else {
           core.exportVariable('Qt6_DIR', qtPath);
         }
-        core.exportVariable('QT_PLUGIN_PATH', qtPath + '/plugins');
-        core.exportVariable('QML2_IMPORT_PATH', qtPath + '/qml');
-        core.addPath(qtPath + "/bin");
+        core.exportVariable('QT_PLUGIN_PATH', nativePath(qtPath + '/plugins'));
+        core.exportVariable('QML2_IMPORT_PATH', nativePath(qtPath + '/qml'));
+        core.addPath(nativePath(qtPath + "/bin"));
       }
     } catch (error) {
       core.setFailed(error.message);


### PR DESCRIPTION
This PR uses the Node standard library `path` module to convert paths into the native format on every platform.

This action sets several environment variables that include paths. On Windows, many of these paths include `/` instead of `\`, or use some mix of both: 

Example from: https://github.com/jurplel/install-qt-action/runs/3916210538?check_suite_focus=true#step:7:10 
```
  shell: C:\Windows\system32\cmd.EXE /D /E:ON /V:OFF /S /C "CALL "{0}""
  env:
    pythonLocation: C:\hostedtoolcache\windows\Python\3.10.0\x64
    IQTA_TOOLS: D:\a\install-qt-action/Qt/Tools
    Qt5_Dir: D:/a/install-qt-action/Qt/5.9/msvc2017_64
    QT_PLUGIN_PATH: D:/a/install-qt-action/Qt/5.9/msvc2017_64/plugins
    QML2_IMPORT_PATH: D:/a/install-qt-action/Qt/5.9/msvc2017_64/qml
```

On Windows, many programs are resilient to this kind of thing, but several are not. For instance, see the output of `dir %Qt5_DIR%/lib/cmake` in the same workflow: [`Invalid switch - "install-qt-action".`](https://github.com/jurplel/install-qt-action/runs/3916210538?check_suite_focus=true#step:7:18). This happens because `dir`, like many Windows programs, interprets `/` as the beginning of a switch or flag, not as part of a directory separator. 

You could fix this problem by surrounding paths with double-quotes, like this:
```
C:\> dir "%Qt5_DIR%/lib/cmake"
```

This change prevents potential issues on Windows by making sure all the environment variables use the correct path separators. You can see the effects on a successful Windows build here: https://github.com/ddalcino/install-qt-action/runs/3969848239?check_suite_focus=true#step:7:1 In this case, `dir` prints properly, and there are no error messages.