### PR TITLE
Use same devDependencies as `setup-python`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,9 +48,15 @@
       }
     },
     "@types/node": {
-      "version": "12.6.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.9.tgz",
-      "integrity": "sha512-+YB9FtyxXGyD54p8rXwWaN1EWEyar5L58GlGWgtH2I9rGmLGBQcw63+0jw+ujqVavNuO47S1ByAjm9zdHMnskw==",
+      "version": "12.20.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.33.tgz",
+      "integrity": "sha512-5XmYX2GECSa+CxMYaFsr2mrql71Q4EvHjKS+ox/SiwSdaASMoBIWE6UmZqFO+VX1jIcsYLStI4FFoB6V7FeIYw==",
+      "dev": true
+    },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
       "dev": true
     },
     "balanced-match": {
@@ -151,9 +157,9 @@
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "setup-python": "github:actions/setup-python#v2"
   },
   "devDependencies": {
-    "@types/node": "^12.0.4",
-    "typescript": "^3.5.1"
+    "@types/node": "^12.12.31",
+    "@types/semver": "^7.1.0",
+    "typescript": "^3.8.3"
   }
 }


### PR DESCRIPTION
Fix #116.

This eliminates two errors in the "npm run build" step on Windows. It does not attempt to cause the build to fail when `npm run *` commands fail; this appears to be an intractable issue with powershell: see https://github.com/jurplel/install-qt-action/issues/116#issuecomment-933384134.

Successful run of this PR: https://github.com/ddalcino/install-qt-action/actions/runs/1373216276