### PR TITLE
CI (GitHub Actions): replace the misleading step name "npm run build"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: "npm ci"
         run: npm ci
 
-      - name: "npm run build"
+      - name: "npm: build dependencies and this action"
         run: |
           npm run build-setup-python
           npm run build


### PR DESCRIPTION
Hi.

In the workflow log, we can see the following content:

> \> (√) Setup up job
> \> (√) Run actions/checkout@v2
> \> (√) Run actions/setup-node@v1
> \> (√) npm ci
> \> (√) **npm run build**
> \> (√) ...

I think "npm run build" is a misleading name because both "npm ci" and "npm run build" are common npm commands. Before viewing the detailed log or the workflow YAML file, other people (e.g., me) may not know that there are two commands have been executed. Then, when they try to build their own iqta, they will encounter "error TS2307: Cannot find module".