### PR TITLE
Fix detection of Qt architecture directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
             requested: "5.15"
           - version: "6.3.2"  # Qt 6.3 is not an LTS version, so '6.3.*' always resolves to '6.3.2'
             requested: "6.3.*"
+          - version: null   # Tools-only build
+            requested: null
         cache:
           - cached
           - uncached
@@ -70,7 +72,7 @@ jobs:
           npm run build
 
       - name: Install Qt5 with options
-        if: startsWith(matrix.qt.version, '5')
+        if: ${{ matrix.qt.version && startsWith(matrix.qt.version, '5') }}
         uses: ./
         with:
           modules: qtwebengine
@@ -79,7 +81,7 @@ jobs:
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Install Qt6 with options
-        if: startsWith(matrix.qt.version, '6')
+        if: ${{ matrix.qt.version && startsWith(matrix.qt.version, '6') }}
         uses: ./
         with:
           # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
@@ -89,7 +91,7 @@ jobs:
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Configure test project on windows
-        if: startsWith(matrix.os, 'windows')
+        if: ${{ matrix.qt.version && startsWith(matrix.os, 'windows') }}
         env:
           QT_VERSION: ${{ matrix.qt.version }}
         run: |
@@ -100,7 +102,7 @@ jobs:
         shell: cmd
 
       - name: Configure test project on unix
-        if: (!startsWith(matrix.os, 'windows'))
+        if: ${{ matrix.qt.version && !startsWith(matrix.os, 'windows') }}
         env:
           QT_VERSION: ${{ matrix.qt.version }}
         run: |
@@ -112,3 +114,27 @@ jobs:
           fi
           qmake
         shell: bash
+
+      - name: Install tools with options
+        if: ${{ !matrix.qt.version }}
+        uses: ./
+        with:
+          tools-only: true
+          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          cache: ${{ matrix.cache == 'cached' }}
+
+      - name: Test installed tools
+        if: ${{ !matrix.qt.version }}
+        env:
+          # Conditionally set qtcreator path based on os:
+          QTCREATOR_BIN_PATH: ${{ startsWith(matrix.os, 'macos') && '../Qt/Qt Creator.app/Contents/MacOS/' || '../Qt/Tools/QtCreator/bin/' }}
+        shell: bash
+        run: |
+          # Check if QtIFW is installed
+          ls ../Qt/Tools/QtInstallerFramework/*/bin/
+          ../Qt/Tools/QtInstallerFramework/*/bin/archivegen --version
+  
+          # Check if QtCreator is installed: QtCreator includes the CLI program 'qbs' on all 3 platforms
+          ls "${QTCREATOR_BIN_PATH}"
+          [[ -f "${QTCREATOR_BIN_PATH}qbs" ]] && echo "qbs is installed"
+          "${QTCREATOR_BIN_PATH}qbs" --version || echo "qbs installed but fails to run"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,6 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-20.04
-          - ubuntu-18.04
           - windows-2022
           - windows-2019
           - macos-11
@@ -49,10 +48,6 @@ jobs:
           - cached
           - uncached
 
-        # Ubuntu 18 is not a supported target for Qt 6: https://www.qt.io/blog/qt6-development-hosts-and-targets
-        exclude:
-          - os: ubuntu-18.04
-            qt: {version: "6.3.2", requested: "6.3.*"}
     steps:
       - uses: actions/checkout@v3
 
@@ -136,5 +131,4 @@ jobs:
   
           # Check if QtCreator is installed: QtCreator includes the CLI program 'qbs' on all 3 platforms
           ls "${QTCREATOR_BIN_PATH}"
-          [[ -f "${QTCREATOR_BIN_PATH}qbs" ]] && echo "qbs is installed"
-          "${QTCREATOR_BIN_PATH}qbs" --version || echo "qbs installed but fails to run"
+          "${QTCREATOR_BIN_PATH}qbs" --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,13 @@ jobs:
           - windows-2019
           - macos-11
           - macos-12
-        version:
-          - "5.9.0"
-          - "5.15.2"
-          - "6.2.0"
+        qt:
+          - version: "5.9.0"
+            requested: "5.9.0"
+          - version: "5.15.2"
+            requested: "5.15"
+          - version: "6.3.2"  # Qt 6.3 is not an LTS version, so '6.3.*' always resolves to '6.3.2'
+            requested: "6.3.*"
         cache:
           - cached
           - uncached
@@ -47,7 +50,7 @@ jobs:
         # Ubuntu 18 is not a supported target for Qt 6: https://www.qt.io/blog/qt6-development-hosts-and-targets
         exclude:
           - os: ubuntu-18.04
-            version: "6.2.0"
+            qt: {version: "6.3.2", requested: "6.3.*"}
     steps:
       - uses: actions/checkout@v3
 
@@ -67,28 +70,28 @@ jobs:
           npm run build
 
       - name: Install Qt5 with options
-        if: startsWith(matrix.version, '5')
+        if: startsWith(matrix.qt.version, '5')
         uses: ./
         with:
           modules: qtwebengine
-          version: ${{ matrix.version }}
+          version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Install Qt6 with options
-        if: startsWith(matrix.version, '6.2')
+        if: startsWith(matrix.qt.version, '6.3')
         uses: ./
         with:
           # In Qt 6.2.0, qtwebengine requires qtpositioning and qtwebchannel
           modules: qtwebengine qtpositioning qtwebchannel
-          version: ${{ matrix.version }}
+          version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Configure test project on windows
         if: startsWith(matrix.os, 'windows')
         env:
-          QT_VERSION: ${{ matrix.version }}
+          QT_VERSION: ${{ matrix.qt.version }}
         run: |
           cd tests/TestWithModules
           for /f "delims=" %%d in ( 'vswhere.exe -latest -property installationPath' ) do @( call "%%d\VC\Auxiliary\Build\vcvars64.bat" )
@@ -99,7 +102,7 @@ jobs:
       - name: Configure test project on unix
         if: (!startsWith(matrix.os, 'windows'))
         env:
-          QT_VERSION: ${{ matrix.version }}
+          QT_VERSION: ${{ matrix.qt.version }}
         run: |
           cd tests/TestWithModules
           if [[ $QT_VERSION == 6* ]]; then

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,10 +79,10 @@ jobs:
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Install Qt6 with options
-        if: startsWith(matrix.qt.version, '6.3')
+        if: startsWith(matrix.qt.version, '6')
         uses: ./
         with:
-          # In Qt 6.2.0, qtwebengine requires qtpositioning and qtwebchannel
+          # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
           modules: qtwebengine qtpositioning qtwebchannel
           version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator


### PR DESCRIPTION
Fix #165

**Edit:** Added tests for a `tools-only` run, as requested here: https://github.com/jurplel/install-qt-action/issues/165#issuecomment-1399954593. The `tools-only` test is relevant because this PR modifies code that could potentially trigger errors in a `tools-only` run.

As a side effect, this should fix #115.