### PR TITLE
Install py7zr compatible with requested aqtinstall, no matter what

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,14 @@ jobs:
         qt:
           - version: "5.9.0"
             requested: "5.9.0"
+            modules: qtwebengine
           - version: "5.15.2"
             requested: "5.15"
+            modules: qtwebengine
           - version: "6.3.2"  # Qt 6.3 is not an LTS version, so '6.3.*' always resolves to '6.3.2'
             requested: "6.3.*"
+            # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
+            modules: qtwebengine qtpositioning qtwebchannel
           - version: null   # Tools-only build
             requested: null
         cache:
@@ -66,21 +70,10 @@ jobs:
           cd action
           npm run build
 
-      - name: Install Qt5 with options
-        if: ${{ matrix.qt.version && startsWith(matrix.qt.version, '5') }}
+      - name: Install Qt with options
         uses: ./
         with:
-          modules: qtwebengine
-          version: ${{ matrix.qt.requested }}
-          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
-          cache: ${{ matrix.cache == 'cached' }}
-
-      - name: Install Qt6 with options
-        if: ${{ matrix.qt.version && startsWith(matrix.qt.version, '6') }}
-        uses: ./
-        with:
-          # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
-          modules: qtwebengine qtpositioning qtwebchannel
+          modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
           cache: ${{ matrix.cache == 'cached' }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
           - windows-2019
           - macos-11
           - macos-12
+        aqtversion:
+          - null  # use whatever the default is
         qt:
           - version: "5.9.0"
             requested: "5.9.0"
@@ -51,6 +53,14 @@ jobs:
         cache:
           - cached
           - uncached
+        include:
+          - os: ubuntu-22.04
+            aqtversion: "==3.1.*"
+            qt:
+              version: "5.15.2"
+              requested: "5.15"
+              modules: qtwebengine
+
 
     steps:
       - uses: actions/checkout@v3
@@ -70,9 +80,20 @@ jobs:
           cd action
           npm run build
 
-      - name: Install Qt with options
+      - name: Install Qt with options and default aqtversion
+        if: ${{ !matrix.aqtversion && matrix.qt.version }}
         uses: ./
         with:
+          modules: ${{ matrix.qt.modules }}
+          version: ${{ matrix.qt.requested }}
+          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          cache: ${{ matrix.cache == 'cached' }}
+
+      - name: Install Qt with options and specified aqtversion
+        if: ${{ matrix.aqtversion && matrix.qt.version }}
+        uses: ./
+        with:
+          aqtversion: ${{ matrix.aqtversion }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -296,13 +296,11 @@ const run = async (): Promise<void> => {
         await exec("brew install p7zip");
       }
 
-      // Install aqtinstall
-      await execPython("pip install", [
-        "setuptools",
-        "wheel",
-        `"py7zr${inputs.py7zrVersion}"`,
-        `"aqtinstall${inputs.aqtVersion}"`,
-      ]);
+      // Install dependencies via pip
+      await execPython("pip install", ["setuptools", "wheel", `"py7zr${inputs.py7zrVersion}"`]);
+
+      // Install aqtinstall separately: allows aqtinstall to override py7zr if required
+      await execPython("pip install", [`"aqtinstall${inputs.aqtVersion}"`]);
 
       // Install Qt
       if (!inputs.toolsOnly) {


### PR DESCRIPTION
This change allows `aqtinstall` to override the default or requested version of py7zr, in the event that the default or requested version is not compatible with the requested version of `aqtinstall`.

IMHO the user should not ever need to know anything about the `py7zr` dependency, and this action should just install aqtinstall properly, no matter what. This change should guarantee that.

Fix #176