### PR TITLE
Add options to install source, docs, and examples

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,8 @@ jobs:
           - macos-12
         aqtversion:
           - null  # use whatever the default is
+        src-doc-examples:
+          - false
         qt:
           - version: "5.9.0"
             requested: "5.9.0"
@@ -48,12 +50,31 @@ jobs:
             requested: "6.3.*"
             # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
             modules: qtwebengine qtpositioning qtwebchannel
-          - version: null   # Tools-only build
-            requested: null
+          - tools-only-build: true
         cache:
           - cached
           - uncached
         include:
+          - os: ubuntu-20.04
+            src-doc-examples: true
+            source: true
+            src-archives: qtcharts
+            check-dir: ../Qt/5.15.2/Src
+            check: qtcharts/src/src.pro
+          - os: ubuntu-20.04
+            src-doc-examples: true
+            documentation: true
+            doc-archives: qmake
+            doc-modules: qtcharts qtwebengine
+            check-dir: ../Qt/Docs/Qt-5.15.2
+            check: qmake/qmake-tutorial.html qtcharts/qtcharts-index.html qtwebengine/qtwebengine-index.html
+          - os: ubuntu-20.04
+            src-doc-examples: true
+            examples: true
+            example-archives: qtsensors
+            example-modules: qtcharts qtwebengine
+            check-dir: ../Qt/Examples/Qt-5.15.2
+            check: charts/charts.pro sensors/sensors.pro webengine/webengine.pro
           - os: ubuntu-22.04
             aqtversion: "==3.1.*"
             qt:
@@ -124,8 +145,44 @@ jobs:
           qmake
         shell: bash
 
+      - name: Install source
+        if: ${{ matrix.source }}
+        uses: ./
+        with:
+          version: "5.15.2"
+          source: true
+          no-qt-binaries: true
+          src-archives: ${{ matrix.src-archives }}
+
+      - name: Install docs
+        if: ${{ matrix.documentation }}
+        uses: ./
+        with:
+          version: "5.15.2"
+          documentation: true
+          no-qt-binaries: true
+          doc-archives: ${{ matrix.doc-archives }}
+          doc-modules: ${{ matrix.doc-modules }}
+
+      - name: Install examples
+        if: ${{ matrix.examples }}
+        uses: ./
+        with:
+          version: "5.15.2"
+          examples: true
+          no-qt-binaries: true
+          example-archives: ${{ matrix.example-archives }}
+          example-modules: ${{ matrix.example-modules }}
+
+      - name: Test source, docs, examples
+        if: ${{ matrix.src-doc-examples }}
+        shell: bash
+        run: |
+          cd ${{ matrix.check-dir }}
+          ls ${{ matrix.check }}
+
       - name: Install tools with options
-        if: ${{ !matrix.qt.version }}
+        if: ${{ matrix.qt.tools-only-build }}
         uses: ./
         with:
           tools-only: true
@@ -133,7 +190,7 @@ jobs:
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Test installed tools
-        if: ${{ !matrix.qt.version }}
+        if: ${{ matrix.qt.tools-only-build }}
         env:
           # Conditionally set qtcreator path based on os:
           QTCREATOR_BIN_PATH: ${{ startsWith(matrix.os, 'macos') && '../Qt/Qt Creator.app/Contents/MacOS/' || '../Qt/Tools/QtCreator/bin/' }}

--- a/README.md
+++ b/README.md
@@ -123,9 +123,17 @@ Set this to false if you want to avoid setting environment variables for whateve
 
 Default: `true`
 
+### `no-qt-binaries`
+
+Set this to true if you want to skip installing Qt. 
+This option is useful if you want to install tools, source, documentation, or examples.
+
+Default: `false`
+
 ### `tools-only`
 
-Set this to true if you only want to install tools, and not Qt.
+This is a synonym for `no-qt-binaries`. It only exists to preserve backwards compatibility.
+If you set either `no-qt-binaries` or `tools-only` to `true`, you will skip installation of Qt.
 
 Default: `false`
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,79 @@ For example, this value will install the most recent versions of QtIFW and QtCre
 
 You can find a full list of tools easily by using [this awesome website](https://ddalcino.github.io/aqt-list-server/).
 
+### `source`
+
+Set this to `true` to install Qt source code. Incompatible with `aqtinstall < 2.0.4`.
+
+Default: `false`
+
+### `src-archives`
+
+String with whitespace delimited list of source archives to install, with each entry separated by a space.
+Has no effect unless `source` is set to `true`.
+Useful to limit download size.
+
+See the `--archives` flag for [aqt install-src](https://aqtinstall.readthedocs.io/en/latest/cli.html#install-src-command) for more details.
+Use [aqt list-src](https://aqtinstall.readthedocs.io/en/latest/cli.html#list-src-command) to see available options.
+
+Default: none
+
+### `documentation`
+
+Set this to `true` to install Qt documentation files. Incompatible with `aqtinstall < 2.0.4`.
+
+Default: `false`
+
+### `doc-archives`
+
+String with whitespace delimited list of documentation archives to install, with each entry separated by a space.
+Has no effect unless `documentation` is set to `true`.
+Useful to limit download size.
+
+See the `--archives` flag for [aqt install-doc](https://aqtinstall.readthedocs.io/en/latest/cli.html#install-doc-command) for more details.
+Use [aqt list-doc](https://aqtinstall.readthedocs.io/en/latest/cli.html#list-doc-command) to see available options.
+
+Default: none
+
+### `doc-modules`
+
+String with whitespace delimited list of documentation modules to install, with each entry separated by a space.
+Has no effect unless `documentation` is set to `true`.
+Each module contains extra documentation not included with the base installation.
+
+See the `--modules` flag for [aqt install-doc](https://aqtinstall.readthedocs.io/en/latest/cli.html#install-doc-command) for more details.
+Use [aqt list-doc](https://aqtinstall.readthedocs.io/en/latest/cli.html#list-doc-command) to see available options.
+
+Default: none
+
+### `examples`
+
+Set this to `true` to install Qt example code. Incompatible with `aqtinstall < 2.0.4`.
+
+Default: `false`
+
+### `example-archives`
+
+String with whitespace delimited list of example archives to install, with each entry separated by a space.
+Has no effect unless `examples` is set to `true`.
+Useful to limit download size.
+
+See the `--archives` flag for [aqt install-example](https://aqtinstall.readthedocs.io/en/latest/cli.html#install-example-command) for more details.
+Use [aqt list-example](https://aqtinstall.readthedocs.io/en/latest/cli.html#list-example-command) to see available options.
+
+Default: none
+
+### `example-modules`
+
+String with whitespace delimited list of example modules to install, with each entry separated by a space.
+Has no effect unless `examples` is set to `true`.
+Each module contains extra examples not included with the base installation.
+
+See the `--modules` flag for [aqt install-example](https://aqtinstall.readthedocs.io/en/latest/cli.html#install-example-command) for more details.
+Use [aqt list-example](https://aqtinstall.readthedocs.io/en/latest/cli.html#list-example-command) to see available options.
+
+Default: none
+
 ### `set-env`
 Set this to false if you want to avoid setting environment variables for whatever reason.
 

--- a/action.yml
+++ b/action.yml
@@ -42,8 +42,11 @@ inputs:
   set-env:
     default: true
     description: Whether or not to set environment variables after running aqtinstall
+  no-qt-binaries:
+    description: Turns off installation of Qt. Useful for installing tools, source, documentation, or examples.
+    default: false
   tools-only:
-    description: Whether or not to actually install Qt or just the tools from the tools argument
+    description: Synonym for `no-qt-binaries`, used for backwards compatibility.
     default: false
   aqtversion:
     description: Version of aqtinstall to use in case of issues
@@ -53,6 +56,25 @@ inputs:
     default: ==0.19.*
   extra:
     description: Any extra arguments to append to the back
+  source:
+    default: false
+    description: Whether or not to install Qt source code.
+  src-archives:
+    description: Space-separated list of .7z source archives to install. Used to reduce download/image sizes.
+  documentation:
+    default: false
+    description: Whether or not to install Qt documentation.
+  doc-archives:
+    description: Space-separated list of .7z docs archives to install. Used to reduce download/image sizes.
+  doc-modules:
+    description: Space-separated list of additional documentation modules to install.
+  examples:
+    default: false
+    description: Whether or not to install Qt example code.
+  example-archives:
+    description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
+  example-modules:
+    description: Space-separated list of additional example modules to install.
 runs:
   using: "composite"
   steps:
@@ -77,7 +99,16 @@ runs:
       cache-key-prefix: ${{ inputs.cache-key-prefix }}
       tools: ${{ inputs.tools }}
       set-env: ${{ inputs.set-env }}
+      no-qt-binaries: ${{ inputs.no-qt-binaries }}
       tools-only: ${{ inputs.tools-only }}
       aqtversion: ${{ inputs.aqtversion }}
       py7zrversion: ${{ inputs.py7zrversion }}
+      source: ${{ inputs.source }}
+      src-archives: ${{ inputs.src-archives }}
+      documentation: ${{ inputs.documentation }}
+      doc-archives: ${{ inputs.doc-archives }}
+      doc-modules: ${{ inputs.doc-modules }}
+      examples: ${{ inputs.examples }}
+      example-archives: ${{ inputs.example-archives }}
+      example-modules: ${{ inputs.example-modules }}
       extra: ${{ inputs.extra }}

--- a/action/action.yml
+++ b/action/action.yml
@@ -53,6 +53,25 @@ inputs:
     default: ==0.19.*
   extra:
     description: Any extra arguments to append to the back
+  source:
+    default: false
+    description: Whether or not to install Qt source code.
+  src-archives:
+    description: Space-separated list of .7z source archives to install. Used to reduce download/image sizes.
+  documentation:
+    default: false
+    description: Whether or not to install Qt documentation.
+  doc-archives:
+    description: Space-separated list of .7z docs archives to install. Used to reduce download/image sizes.
+  doc-modules:
+    description: Space-separated list of additional documentation modules to install.
+  examples:
+    default: false
+    description: Whether or not to install Qt example code.
+  example-archives:
+    description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
+  example-modules:
+    description: Space-separated list of additional example modules to install.
 runs:
   using: node16
   main: lib/main.js

--- a/action/action.yml
+++ b/action/action.yml
@@ -39,8 +39,11 @@ inputs:
   set-env:
     default: true
     description: Whether or not to set environment variables after running aqtinstall
+  no-qt-binaries:
+    description: Turns off installation of Qt. Useful for installing tools, source, documentation, or examples.
+    default: false
   tools-only:
-    description: Whether or not to actually install Qt or just the tools from the tools argument
+    description: Synonym for `no-qt-binaries`, used for backwards compatibility.
     default: false
   aqtversion:
     description: Version of aqtinstall to use in case of issues

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -68,7 +68,7 @@ class Inputs {
   readonly installDeps: boolean | "nosudo";
   readonly cache: boolean;
   readonly cacheKeyPrefix: string;
-  readonly toolsOnly: boolean;
+  readonly isInstallQtBinaries: boolean;
   readonly setEnv: boolean;
 
   readonly aqtVersion: string;
@@ -166,7 +166,8 @@ class Inputs {
 
     this.cacheKeyPrefix = core.getInput("cache-key-prefix");
 
-    this.toolsOnly = Inputs.getBoolInput("tools-only");
+    this.isInstallQtBinaries =
+      !Inputs.getBoolInput("tools-only") && !Inputs.getBoolInput("no-qt-binaries");
 
     this.setEnv = Inputs.getBoolInput("set-env");
 
@@ -286,7 +287,7 @@ const run = async (): Promise<void> => {
       await execPython("pip install", [`"aqtinstall${inputs.aqtVersion}"`]);
 
       // Install Qt
-      if (!inputs.toolsOnly) {
+      if (inputs.isInstallQtBinaries) {
         const qtArgs = [inputs.host, inputs.target, inputs.version];
 
         if (inputs.arch) {
@@ -334,7 +335,7 @@ const run = async (): Promise<void> => {
       if (inputs.tools.length) {
         core.exportVariable("IQTA_TOOLS", nativePath(`${inputs.dir}/Tools`));
       }
-      if (!inputs.toolsOnly) {
+      if (inputs.isInstallQtBinaries) {
         const qtPath = nativePath(locateQtArchDir(inputs.dir));
         if (process.platform === "linux") {
           setOrAppendEnvVar("LD_LIBRARY_PATH", nativePath(`${qtPath}/lib`));

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -143,38 +143,17 @@ class Inputs {
     }
     this.dir = `${dir}/Qt`;
 
-    const modules = core.getInput("modules");
-    if (modules) {
-      this.modules = modules.split(" ");
-    } else {
-      this.modules = [];
-    }
+    this.modules = Inputs.getStringArrayInput("modules");
 
-    const archives = core.getInput("archives");
-    if (archives) {
-      this.archives = archives.split(" ");
-    } else {
-      this.archives = [];
-    }
+    this.archives = Inputs.getStringArrayInput("archives");
 
-    const tools = core.getInput("tools");
-    if (tools) {
-      this.tools = [];
-      for (const tool of tools.split(" ")) {
-        // The tools inputs have the tool name, variant, and arch delimited by a comma
-        // aqt expects spaces instead
-        this.tools.push(tool.replace(/,/g, " "));
-      }
-    } else {
-      this.tools = [];
-    }
+    this.tools = Inputs.getStringArrayInput("tools").map(
+      // The tools inputs have the tool name, variant, and arch delimited by a comma
+      // aqt expects spaces instead
+      (tool: string): string => tool.replace(/,/g, " ")
+    );
 
-    const extra = core.getInput("extra");
-    if (extra) {
-      this.extra = extra.split(" ");
-    } else {
-      this.extra = [];
-    }
+    this.extra = Inputs.getStringArrayInput("extra");
 
     const installDeps = core.getInput("install-deps").toLowerCase();
     if (installDeps === "nosudo") {
@@ -233,6 +212,10 @@ class Inputs {
 
   private static getBoolInput(name: string): boolean {
     return core.getInput(name).toLowerCase() === "true";
+  }
+  private static getStringArrayInput(name: string): string[] {
+    const content = core.getInput(name);
+    return content ? content.split(" ") : [];
   }
 }
 


### PR DESCRIPTION
Fix #87

The code for installing source is very similar to the code that installs examples and docs, so I went ahead and implemented all of them.

This PR probably includes more refactoring than it should, but I was careful to keep all the refactors in their own commits, in case you want to move them to a separate PR. This PR would be too tedious for me to write without using these refactors, so they're included anyway.
* a6c6d1138781b492d3c5764fa58c762a77804d1d
* 9307e28277dcad7f866fdd95b8753852f90d3d0e
* a4367ae45f326b147864156266e3c9881568ddbc
* 22b24469d9cbcdd6ca55c005759af6819a280087

Please see the changes to the README.md for a discussion of all the new features added here.