### PR TITLE
[v4] Add installed tools to path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,6 +51,7 @@ jobs:
             # In Qt 6.2.0+, qtwebengine requires qtpositioning and qtwebchannel
             modules: qtwebengine qtpositioning qtwebchannel
           - tools-only-build: true
+            add-tools-to-path: true
         cache:
           - cached
           - uncached
@@ -81,6 +82,10 @@ jobs:
               version: "5.15.2"
               requested: "5.15"
               modules: qtwebengine
+          - os: ubuntu-22.04
+            qt:
+              tools-only-build: true
+              add-tools-to-path: false
 
 
     steps:
@@ -189,10 +194,11 @@ jobs:
         with:
           tools-only: true
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          add-tools-to-path: ${{ matrix.qt.add-tools-to-path }}
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Test installed tools
-        if: ${{ matrix.qt.tools-only-build }}
+        if: ${{ matrix.qt.tools-only-build && matrix.qt.add-tools-to-path }}
         shell: bash
         run: |
           echo "Path: ${PATH}"
@@ -203,3 +209,19 @@ jobs:
           # Check if QtCreator is installed: QtCreator includes the CLI program 'qbs' on all 3 platforms
           which qbs
           qbs --version
+
+      - name: Test that installed tools are not in the path
+        if: ${{ matrix.qt.tools-only-build && !matrix.qt.add-tools-to-path }}
+        shell: bash
+        run: |
+          echo "Path: ${PATH}"
+          # Check that QtIFW has been installed
+          ls ../Qt/Tools/QtInstallerFramework/*/bin/ | grep archivegen
+          
+          # Check that QtIFW is not in the path
+          ! which archivegen
+          ! archivegen --version
+          
+          # Check that qbs (from QtCreator) is not in the path
+          ! which qbs
+          ! qbs --version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,15 +193,13 @@ jobs:
 
       - name: Test installed tools
         if: ${{ matrix.qt.tools-only-build }}
-        env:
-          # Conditionally set qtcreator path based on os:
-          QTCREATOR_BIN_PATH: ${{ startsWith(matrix.os, 'macos') && '../Qt/Qt Creator.app/Contents/MacOS/' || '../Qt/Tools/QtCreator/bin/' }}
         shell: bash
         run: |
+          echo "Path: ${PATH}"
           # Check if QtIFW is installed
-          ls ../Qt/Tools/QtInstallerFramework/*/bin/
-          ../Qt/Tools/QtInstallerFramework/*/bin/archivegen --version
+          which archivegen
+          archivegen --version
   
           # Check if QtCreator is installed: QtCreator includes the CLI program 'qbs' on all 3 platforms
-          ls "${QTCREATOR_BIN_PATH}"
-          "${QTCREATOR_BIN_PATH}qbs" --version
+          which qbs
+          qbs --version

--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ Example value: `--external 7z`
 ## More info
 For more in-depth and certifiably up-to-date documentation, check the documentation for aqtinstall [here](https://aqtinstall.readthedocs.io/en/latest/getting_started.html).
 
+Any tools you installed with the `tools` key will be added to the beginning of your `PATH` environment variable.
+Specifically, any `bin` directories within the tool's directory will be added.
+On MacOS, if the tool is an app bundle, then the `.app/Contents/MacOS` folder will also be added to your `PATH`.
+
 The Qt bin directory is appended to your `path` environment variable.
 `Qt5_DIR` is also set appropriately for CMake if you are using Qt 5.
 In addition, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set accordingly. `IQTA_TOOLS` is set to the "Tools" directory if tools are installed as well.

--- a/README.md
+++ b/README.md
@@ -125,6 +125,22 @@ For example, this value will install the most recent versions of QtIFW and QtCre
 
 You can find a full list of tools easily by using [this awesome website](https://ddalcino.github.io/aqt-list-server/).
 
+### `add-tools-to-path`
+
+When set to `true`, and the `tools` parameter is non-empty,
+the following paths will be prepended to the `PATH` variable: 
+* `Tools/**/bin`
+* `*.app/Contents/MacOS`
+* `*.app/**/bin`
+
+Most tools end up in the `Tools` folder, and have a `bin` directory containing CLI tools.
+On MacOS, several tools are packaged in `.app` bundles, and CLI tools are spread out among various `bin` folders
+and the `Contents/MacOS` folder.
+
+Distinct from, and not affected by, the `set-env` parameter.
+
+Default: `true`
+
 ### `source`
 
 Set this to `true` to install Qt source code. Incompatible with `aqtinstall < 2.0.4`.
@@ -200,6 +216,7 @@ Default: none
 
 ### `set-env`
 Set this to false if you want to avoid setting environment variables for whatever reason.
+Has no effect on `tools` paths; to modify these you must use `add-tools-to-path`.
 
 Default: `true`
 

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -15,6 +15,12 @@
   If your action uses this variable for any other purpose, you should update it to use `QT_ROOT_DIR` instead.
 * Removed the `Qt5_Dir` and `Qt6_DIR` environment variables, because they are not used by CMake.
   If your action uses these variables, you should update them to use `QT_ROOT_DIR` instead.
+* Any tools you installed with the `tools` key will be added to the beginning of your `PATH` environment variable.
+  Specifically, any `bin` directories within the tool's directory will be added.
+  On MacOS, if the tool is an app bundle, then the `.app/Contents/MacOS` folder will also be added to your `PATH`.
+  You should take care to investigate the order of the new `PATH` variable to make sure that the tools you are using
+  are not clobbered by tools in some other path. You may need to rearrange the order of your workflow steps, so that
+  any clobbered tools are added to the path later than the ones added by this action.
 
 ## v3
 * Updated `aqtinstall` to version 2.1.* by default.

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -18,9 +18,11 @@
 * Any tools you installed with the `tools` key will be added to the beginning of your `PATH` environment variable.
   Specifically, any `bin` directories within the tool's directory will be added.
   On MacOS, if the tool is an app bundle, then the `.app/Contents/MacOS` folder will also be added to your `PATH`.
-  You should take care to investigate the order of the new `PATH` variable to make sure that the tools you are using
-  are not clobbered by tools in some other path. You may need to rearrange the order of your workflow steps, so that
-  any clobbered tools are added to the path later than the ones added by this action.
+  * You should take care to investigate the order of the new `PATH` variable to make sure that the tools you are using
+    are not clobbered by tools in some other path. You may need to rearrange the order of your workflow steps, so that
+    any clobbered tools are added to the path later than the ones added by this action.
+  * If the added tool paths are still causing trouble, you can remove them from the `PATH` by setting
+    `add-tools-to-path: false`. 
 
 ## v3
 * Updated `aqtinstall` to version 2.1.* by default.

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
       --
       specify comma-separated argument lists which are themselves separated by spaces:
       <tool_name>,<tool_version>,<tool_arch>
+  add-tools-to-path:
+    default: true
+    description: When true, prepends directories of tools to PATH environment variable.
   set-env:
     default: true
     description: Whether or not to set environment variables after running aqtinstall
@@ -98,6 +101,7 @@ runs:
       cache: ${{ inputs.cache }}
       cache-key-prefix: ${{ inputs.cache-key-prefix }}
       tools: ${{ inputs.tools }}
+      add-tools-to-path: ${{ inputs.add-tools-to-path }}
       set-env: ${{ inputs.set-env }}
       no-qt-binaries: ${{ inputs.no-qt-binaries }}
       tools-only: ${{ inputs.tools-only }}

--- a/action/action.yml
+++ b/action/action.yml
@@ -36,6 +36,9 @@ inputs:
       --
       specify comma-separated argument lists which are themselves separated by spaces:
       <tool_name>,<tool_version>,<tool_arch>
+  add-tools-to-path:
+    default: true
+    description: When true, prepends directories of tools to PATH environment variable.
   set-env:
     default: true
     description: Whether or not to set environment variables after running aqtinstall

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -25,6 +25,12 @@ const setOrAppendEnvVar = (name: string, value: string): void => {
   core.exportVariable(name, newValue);
 };
 
+const toolsPaths = (installDir: string): string =>
+  ["Tools/**/bin", "*.app/Contents/MacOS", "*.app/**/bin"]
+    .flatMap((p: string): string[] => glob.sync(`${installDir}/${p}`))
+    .map(nativePath)
+    .join(":");
+
 const pythonCommand = (command: string, args: readonly string[]): string => {
   const python = process.platform === "win32" ? "python" : "python3";
   return `${python} -m ${command} ${args.join(" ")}`;
@@ -405,6 +411,7 @@ const run = async (): Promise<void> => {
     if (inputs.setEnv) {
       if (inputs.tools.length) {
         core.exportVariable("IQTA_TOOLS", nativePath(`${inputs.dir}/Tools`));
+        setOrAppendEnvVar("PATH", toolsPaths(inputs.dir));
       }
       if (inputs.isInstallQtBinaries) {
         const qtPath = nativePath(locateQtArchDir(inputs.dir));

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -88,6 +88,7 @@ class Inputs {
   readonly modules: string[];
   readonly archives: string[];
   readonly tools: string[];
+  readonly addToolsToPath: boolean;
   readonly extra: string[];
 
   readonly src: boolean;
@@ -188,6 +189,8 @@ class Inputs {
       // aqt expects spaces instead
       (tool: string): string => tool.replace(/,/g, " ")
     );
+
+    this.addToolsToPath = Inputs.getBoolInput("add-tools-to-path");
 
     this.extra = Inputs.getStringArrayInput("extra");
 
@@ -406,11 +409,15 @@ const run = async (): Promise<void> => {
       core.info(`Automatic cache saved with id ${cacheId}`);
     }
 
+    // Add tools to path
+    if (inputs.addToolsToPath && inputs.tools.length) {
+      toolsPaths(inputs.dir).map(nativePath).forEach(core.addPath);
+    }
+
     // Set environment variables
     if (inputs.setEnv) {
       if (inputs.tools.length) {
         core.exportVariable("IQTA_TOOLS", nativePath(`${inputs.dir}/Tools`));
-        toolsPaths(inputs.dir).map(nativePath).forEach(core.addPath);
       }
       if (inputs.isInstallQtBinaries) {
         const qtPath = nativePath(locateQtArchDir(inputs.dir));

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -25,11 +25,10 @@ const setOrAppendEnvVar = (name: string, value: string): void => {
   core.exportVariable(name, newValue);
 };
 
-const toolsPaths = (installDir: string): string =>
-  ["Tools/**/bin", "*.app/Contents/MacOS", "*.app/**/bin"]
-    .flatMap((p: string): string[] => glob.sync(`${installDir}/${p}`))
-    .map(nativePath)
-    .join(":");
+const toolsPaths = (installDir: string): string[] =>
+  ["Tools/**/bin", "*.app/Contents/MacOS", "*.app/**/bin"].flatMap((p: string): string[] =>
+    glob.sync(`${installDir}/${p}`)
+  );
 
 const pythonCommand = (command: string, args: readonly string[]): string => {
   const python = process.platform === "win32" ? "python" : "python3";
@@ -411,7 +410,7 @@ const run = async (): Promise<void> => {
     if (inputs.setEnv) {
       if (inputs.tools.length) {
         core.exportVariable("IQTA_TOOLS", nativePath(`${inputs.dir}/Tools`));
-        setOrAppendEnvVar("PATH", toolsPaths(inputs.dir));
+        toolsPaths(inputs.dir).map(nativePath).forEach(core.addPath);
       }
       if (inputs.isInstallQtBinaries) {
         const qtPath = nativePath(locateQtArchDir(inputs.dir));

--- a/action/tsconfig.json
+++ b/action/tsconfig.json
@@ -20,6 +20,7 @@
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+    "lib": ["ES2019"],
 
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */


### PR DESCRIPTION
Fix #157 

As discussed in #157, the preferred way to handle this is to append tool paths to the PATH, so that the added paths don't unintentionally override other tools that you're trying to keep in your environment. The tools provided by aqtinstall tend to include a lot of binaries that you may or may not actually need.

Unfortunately, every attempt I have made to append tool paths has failed miserably on Windows. Github toolkit/core provides a convenient and robust method of prepending to the path, and that's what this PR uses, because it works really well. Unfortunately, Github did not provide an equivalent "append to path" method that works on Windows, and nothing I have tried has worked so far.

I am submitting this as a draft because it prepends to the path, rather than appends. Hopefully this will help generate ideas and discussion as to how to move forward.