### PR TITLE
Two small fixes in readme file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Example value: `--external 7z`
 ## More info
 For more in-depth and certifiably up-to-date documentation, check the documentation for aqtinstall [here](https://aqtinstall.readthedocs.io/en/latest/getting_started.html).
 
-The Qt bin directory is appended to your `path` environment variable. `Qt5_DIR`/`Qt6_DIR` is also set appropriately for cmake.
+The Qt bin directory is appended to your `path` environment variable. `Qt5_DIR`/`Qt6_DIR` is also set appropriately for CMake.
 In addition, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set accordingly. `IQTA_TOOLS` is set to the "Tools" directory if tools are installed as well.
 
 Big thanks to the [aqtinstall](https://github.com/miurahr/aqtinstall/) developer for making this easy. Please go support [miurahr](https://github.com/miurahr/aqtinstall), he did all of the hard work here ([his liberapay](https://liberapay.com/miurahr)).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Possible values: `desktop`, `android`, `ios`, or `winrt`
 Default: `desktop`
 
 ### `arch`
-This is the target architecture that your program will be built for. This is only used for Windows and Android.
+This is the target architecture that your program will be built for.
 
 **Linux x86 packages are not supported by this action.** Qt does not offer pre-built Linux x86 packages. Please consider using your distro's repository or building it manually.
 


### PR DESCRIPTION
Accoding to the [website](https://ddalcino.github.io/aqt-list-server/) provided by you, the arch option also is useful for MacOS, for there are two arch option, `clangd_64` and `wasm_32`, from Qt 5.13.2 version in MacOS platform. So I deleted this line:

>This is only used for Windows and Android.

And I also made a commit to change `cmake` to `CMake`, which is the official spell. I think it's more appropriate.