### PR TITLE
[v4] Install desktop Qt when required to by Qt 6.2+ mobile and WASM

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -1,0 +1,82 @@
+name: CI-android
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-22.04
+          - windows-2022
+          - macos-12
+        qt:
+          - version: "5.15.2"
+            ndk-version: r21e
+            modules:
+            example-archives: qtbase qtsensors
+            example-modules:
+          - version: "6.3.2"
+            ndk-version: r21e
+            modules: qtsensors
+            example-archives: qtbase
+            example-modules:  qtsensors
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+          cache-dependency-path: action/
+
+      - run: |
+          cd action
+          npm ci || npm install
+        shell: bash
+
+      - run: |
+          cd action
+          npm run build
+
+      - name: Install Qt
+        uses: ./
+        with:
+          target: android
+          modules: ${{ matrix.qt.modules }}
+          version: ${{ matrix.qt.version }}
+          examples: true
+          example-archives: ${{ matrix.qt.example-archives }}
+          example-modules:  ${{ matrix.qt.example-modules }}
+
+      - name: Install Android NDK
+        shell: bash
+        # Links to NDK are at https://github.com/android/ndk/wiki/Unsupported-Downloads
+        run: |
+          if [[ "${RUNNER_OS}" == "Linux" ]]; then
+            export TARGET_ARCH="linux"
+          elif [[ "${RUNNER_OS}" == "Windows" ]]; then
+            export TARGET_ARCH="windows"
+          else
+            export TARGET_ARCH="darwin"
+          fi
+          export NDK_VER_NUM=$(echo ${{ matrix.qt.ndk-version }} | sed -e 's/r(\d+).*/$1/g')
+          # If it's less than 23, append -x86_64
+          if (( "${NDK_VER_NUM}" < 23 )); then
+            export TARGET_ARCH="${TARGET_ARCH}-x86_64"
+          fi;
+          curl -O "https://dl.google.com/android/repository/android-ndk-${{ matrix.qt.ndk-version }}-${TARGET_ARCH}.zip"
+          unzip "android-ndk-${{ matrix.qt.ndk-version }}-${TARGET_ARCH}.zip"
+
+      - name: Build test project
+        env:
+          QT_VERSION: ${{ matrix.qt.version }}
+        run: |
+          export ANDROID_NDK_ROOT=$(pwd)/android-ndk-${{ matrix.qt.ndk-version }}
+          cd ../Qt/Examples/Qt-${{ matrix.qt.version }}/sensors/accelbubble
+          qmake || qmake.bat
+          make
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ You know what's easier than dealing with that? Just using this:
 
 All done.
 
+## Upgrade Guides
+Each new major version of this project includes changes that can break workflows written to use an older version of
+this project. These changes are summarized here, to help you upgrade your existing workflows.
+
+[Upgrading `install-qt-action`](README_upgrade_guide.md)
+
 ## Options
 
 ### `version`

--- a/README.md
+++ b/README.md
@@ -214,12 +214,12 @@ Default: `false`
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `==2.1.*`
+Default: `==3.1.*`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
 
-Default: `==0.19.*`
+Default: `==0.20.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
@@ -246,8 +246,8 @@ Example value: `--external 7z`
         tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'true'
         tools-only: 'false'
-        aqtversion: '==2.1.*'
-        py7zrversion: '==0.19.*'
+        aqtversion: '==3.1.*'
+        py7zrversion: '==0.20.*'
         extra: '--external 7z'
 ```
 

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -1,6 +1,14 @@
 # Upgrading `install-qt-action`
 
 ## Unreleased
+* Updated `aqtinstall` to version 3.1.* by default.
+* Use the `--autodesktop` flag to automatically install the desktop version of Qt, parallel to any WASM or mobile
+  versions of Qt 6.2 and above.
+  * If your action installed Qt 6.2+ for Android or WASM using `install-qt-action@v3`, then your action would have
+    needed to install the desktop version of Qt alongside the WASM/mobile version of Qt, otherwise it would not have
+    worked properly. As long as you are using `aqtinstall v3` or higher, the new version of `install-qt-action` will do
+    that automatically, so you can remove the second step where you add the parallel desktop version of Qt.
+    If you don't, your workflow will install desktop Qt twice.
 
 ## v3
 * Updated `aqtinstall` to version 2.1.* by default.

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -1,0 +1,13 @@
+# Upgrading `install-qt-action`
+
+## Unreleased
+
+## v3
+* Updated `aqtinstall` to version 2.1.* by default.
+  See [changelog entry](https://github.com/miurahr/aqtinstall/blob/master/docs/CHANGELOG.rst#v210-14-apr-2022) for details.
+  * `aqtinstall` v 2.1.0 now checks that the SHA256 checksums reported at https://download.qt.io matches the 7z archives
+    that it downloads [aqtinstall#493](https://github.com/miurahr/aqtinstall/pull/493). 
+    This change was necessary because the old checksum algorithm, SHA1, is no longer safe to use for this purpose.
+    Unfortunately, SHA256 checksums are often not available for up to 24 hours after new 7z archives are made available at
+    https://download.qt.io, and workflows that use `aqtinstall` v 2.1.0 will fail to install Qt properly during that window.
+    See [aqtinstall#578](https://github.com/miurahr/aqtinstall/issues/578) for further discussion.

--- a/action.yml
+++ b/action.yml
@@ -50,10 +50,10 @@ inputs:
     default: false
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==2.1.*
+    default: ==3.1.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.19.*
+    default: ==0.20.*
   extra:
     description: Any extra arguments to append to the back
   source:

--- a/action/action.yml
+++ b/action/action.yml
@@ -47,10 +47,10 @@ inputs:
     default: false
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==2.1.*
+    default: ==3.1.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.19.*
+    default: ==0.20.*
   extra:
     description: Any extra arguments to append to the back
   source:

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -130,7 +130,16 @@ class Inputs {
     this.arch = core.getInput("arch");
     // Set arch automatically if omitted
     if (!this.arch) {
-      if (this.host === "windows") {
+      if (this.target === "android") {
+        if (
+          compareVersions(this.version, ">=", "5.14.0") &&
+          compareVersions(this.version, "<", "6.0.0")
+        ) {
+          this.arch = "android";
+        } else {
+          this.arch = "android_armv7";
+        }
+      } else if (this.host === "windows") {
         if (compareVersions(this.version, ">=", "5.15.0")) {
           this.arch = "win64_msvc2019_64";
         } else if (compareVersions(this.version, "<", "5.6.0")) {
@@ -139,15 +148,6 @@ class Inputs {
           this.arch = "win64_msvc2015_64";
         } else {
           this.arch = "win64_msvc2017_64";
-        }
-      } else if (this.target === "android") {
-        if (
-          compareVersions(this.version, ">=", "5.14.0") &&
-          compareVersions(this.version, "<", "6.0.0")
-        ) {
-          this.arch = "android";
-        } else {
-          this.arch = "android_armv7";
         }
       }
     }


### PR DESCRIPTION
Fix #181. This will allow both mobile and WASM builds to succeed, when using Qt 6.2+. These new versions of Qt require a parallel installation of the desktop version of Qt, installed alongside the mobile or WASM versions.

As a side effect, this PR also fixes a logic bug in the way the `arch` input is set by default. When the user does not select an arch on Windows, and the target is set to `android`, the action selects a Windows desktop arch instead of an android arch. The change that fixes this issue is in its own commit: 8cd6038e549907ed4b1a590f662432496adb48a1

This PR makes breaking changes, discussed in the new `README_upgrade_guide.md` file. For that reason, this change should not be merged into v3 of this action.

This PR uses #179 as a starting point. I needed to use an example project meant for mobile devices in order to test Qt for Android properly, and there are some good ones in the `Examples` directory that you can install using `aqt install-example`. It was easier to accomplish that using the changes in #179 than in some other way.

I have added tests for android in their own workflow. This will result in some code duplication, but IMHO it's a lot easier to read and to reason about the tests this way than it would have been if I had added the tests to the existing `test.yml` workflow.