### PR TITLE
[v4] Fix `Qt5_DIR` environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
         run: |
           cd tests/TestWithModules
           for /f "delims=" %%d in ( 'vswhere.exe -latest -property installationPath' ) do @( call "%%d\VC\Auxiliary\Build\vcvars64.bat" )
-          IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR%\lib\cmake ) ELSE ( dir %Qt6_DIR%\lib\cmake )
+          IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR% ) ELSE ( dir %QT_ROOT_DIR%\lib\cmake )
           qmake
         shell: cmd
 
@@ -117,9 +117,9 @@ jobs:
         run: |
           cd tests/TestWithModules
           if [[ $QT_VERSION == 6* ]]; then
-            ls "$Qt6_DIR/lib/cmake"
+            ls "${QT_ROOT_DIR}/lib/cmake"
           else
-            ls "$Qt5_DIR/lib/cmake"
+            ls "${Qt5_DIR}"
           fi
           qmake
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -108,6 +108,7 @@ jobs:
           for /f "delims=" %%d in ( 'vswhere.exe -latest -property installationPath' ) do @( call "%%d\VC\Auxiliary\Build\vcvars64.bat" )
           IF "%QT_VERSION:~0,1%"=="5" ( dir %Qt5_DIR% ) ELSE ( dir %QT_ROOT_DIR%\lib\cmake )
           qmake
+          cmake -S . -B ./build
         shell: cmd
 
       - name: Configure test project on unix
@@ -122,6 +123,7 @@ jobs:
             ls "${Qt5_DIR}"
           fi
           qmake
+          cmake -S . -B ./build
         shell: bash
 
       - name: Install tools with options

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ You know what's easier than dealing with that? Just using this:
 
 All done.
 
+## Upgrade Guides
+Each new major version of this project includes changes that can break workflows written to use an older version of
+this project. These changes are summarized here, to help you upgrade your existing workflows.
+
+[Upgrading `install-qt-action`](README_upgrade_guide.md)
+
 ## Options
 
 ### `version`

--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ Android: `android_armv7`
 ### `dir`
 This is the directory prefix that Qt will be installed to.
 
-For example, if you set dir to `${{ github.workspace }}/example/`, your bin folder will be located at `$GITHUB_WORKSPACE/example/Qt/5.15.2/{arch}/bin`. When possible, access your Qt directory through the `Qt5_DIR` or `Qt6_DIR` environment variable.
+For example, if you set dir to `${{ github.workspace }}/example/`, your bin folder will be located at `$GITHUB_WORKSPACE/example/Qt/5.15.2/{arch}/bin`.
+When possible, access your Qt directory through the `QT_ROOT_DIR` environment variable; this will point to `$GITHUB_WORKSPACE/example/Qt/5.15.2/{arch}` in this case.
 
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
@@ -179,8 +180,12 @@ Example value: `--external 7z`
 ## More info
 For more in-depth and certifiably up-to-date documentation, check the documentation for aqtinstall [here](https://aqtinstall.readthedocs.io/en/latest/getting_started.html).
 
-The Qt bin directory is appended to your `path` environment variable. `Qt5_DIR`/`Qt6_DIR` is also set appropriately for CMake.
+The Qt bin directory is appended to your `path` environment variable.
+`Qt5_DIR` is also set appropriately for CMake if you are using Qt 5.
 In addition, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set accordingly. `IQTA_TOOLS` is set to the "Tools" directory if tools are installed as well.
+
+Since the Qt bin directory is in your `path`, you will not need to set the `CMAKE_PREFIX_PATH` CMake variable.
+If you wish to do so, you can set it to either `${QT_ROOT_DIR}` or to `${QT_ROOT_DIR}/lib/cmake`.
 
 Big thanks to the [aqtinstall](https://github.com/miurahr/aqtinstall/) developer for making this easy. Please go support [miurahr](https://github.com/miurahr/aqtinstall), he did all of the hard work here ([his liberapay](https://liberapay.com/miurahr)).
 

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -1,0 +1,13 @@
+# Upgrading `install-qt-action`
+
+## Unreleased
+
+## v3
+* Updated `aqtinstall` to version 2.1.* by default.
+  See [changelog entry](https://github.com/miurahr/aqtinstall/blob/master/docs/CHANGELOG.rst#v210-14-apr-2022) for details.
+  * `aqtinstall` v 2.1.0 now checks that the SHA256 checksums reported at https://download.qt.io matches the 7z archives
+    that it downloads [aqtinstall#493](https://github.com/miurahr/aqtinstall/pull/493). 
+    This change was necessary because the old checksum algorithm, SHA1, is no longer safe to use for this purpose.
+    Unfortunately, SHA256 checksums are often not available for up to 24 hours after new 7z archives are made available at
+    https://download.qt.io, and workflows that use `aqtinstall` v 2.1.0 will fail to install Qt properly during that window.
+    See [aqtinstall#578](https://github.com/miurahr/aqtinstall/issues/578) for further discussion.

--- a/README_upgrade_guide.md
+++ b/README_upgrade_guide.md
@@ -1,6 +1,12 @@
 # Upgrading `install-qt-action`
 
 ## Unreleased
+* Added the `QT_ROOT_DIR` environment variable that points to the root of the Qt installation.
+  This variable points to the same directory as the old `Qt5_DIR` and `Qt6_DIR` variables.
+* Changed `Qt5_DIR` environment variable, so that it points to `${QT_ROOT_DIR}/lib/cmake`, as required by CMake.
+  If your action uses this variable for any other purpose, you should update it to use `QT_ROOT_DIR` instead.
+* Removed the `Qt5_Dir` and `Qt6_DIR` environment variables, because they are not used by CMake.
+  If your action uses these variables, you should update them to use `QT_ROOT_DIR` instead.
 
 ## v3
 * Updated `aqtinstall` to version 2.1.* by default.

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -359,13 +359,11 @@ const run = async (): Promise<void> => {
         if (process.platform !== "win32") {
           setOrAppendEnvVar("PKG_CONFIG_PATH", nativePath(`${qtPath}/lib/pkgconfig`));
         }
-        // If less than qt6, set qt5_dir variable, otherwise set qt6_dir variable
+        // If less than qt6, set Qt5_DIR variable
         if (compareVersions(inputs.version, "<", "6.0.0")) {
-          core.exportVariable("Qt5_Dir", qtPath); // Incorrect name that was fixed, but kept around so it doesn't break anything
-          core.exportVariable("Qt5_DIR", qtPath);
-        } else {
-          core.exportVariable("Qt6_DIR", qtPath);
+          core.exportVariable("Qt5_DIR", nativePath(`${qtPath}/lib/cmake`));
         }
+        core.exportVariable("QT_ROOT_DIR", qtPath);
         core.exportVariable("QT_PLUGIN_PATH", nativePath(`${qtPath}/plugins`));
         core.exportVariable("QML2_IMPORT_PATH", nativePath(`${qtPath}/qml`));
         core.addPath(nativePath(`${qtPath}/bin`));

--- a/tests/TestWithModules/CMakeLists.txt
+++ b/tests/TestWithModules/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+project(whatspoppin VERSION 1.0.0 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+if(CMAKE_VERSION VERSION_LESS "3.7.0")
+  set(CMAKE_INCLUDE_CURRENT_DIR ON)
+endif()
+
+if(DEFINED ENV{Qt5_DIR})
+  find_package(Qt5 COMPONENTS WebEngineWidgets REQUIRED)
+  add_executable(whatspoppin main.cpp)
+  target_link_libraries(whatspoppin Qt5::WebEngineWidgets)
+else()
+  find_package(Qt6 REQUIRED COMPONENTS Core WebEngineWidgets)
+  qt_standard_project_setup()
+  add_executable(whatspoppin main.cpp)
+  target_link_libraries(whatspoppin PRIVATE Qt::WebEngineWidgets Qt6::Core)
+endif()
+


### PR DESCRIPTION
Fix #184.

This adds the `QT_ROOT_DIR` environment variable that takes the place of the old `Qt5_DIR` and `Qt6_DIR` variables, and points `Qt5_DIR` to the location that CMake expects.

Breaking changes are documented in the `README_upgrade_guide.md` file.

Please be aware that this is not a bug fix. I added a `CMakeLists.txt` file to the test project, so that each test run can configure a test project with CMake; these tests were passing before I made any code changes. The changes here are meant to make the action easier for users to understand:
* The `Qt5_DIR` is now given the value that it would need to have to run CMake properly, if the qmake directory had not been added to the path.
* The `Qt5_Dir` and `Qt6_DIR` variables have been removed, since they have no intrinsic purpose other than to preserve the legacy interface. Removing them makes the code easier to maintain and the environment easier to understand.

This PR should not be merged into v3 of this action, owing to breaking changes.