### PR TITLE
Add Windows ARM support

### DIFF
--- a/action/lib/main.js
+++ b/action/lib/main.js
@@ -63,10 +63,10 @@ const locateQtArchDir = (installDir) => {
     const qtArchDirs = glob
         .sync(`${installDir}/[0-9]*/*/bin/qmake*`)
         .map((s) => s.replace(/\/bin\/qmake[^/]*$/, ""));
-    // For Qt6 mobile and wasm installations, a standard desktop Qt installation
-    // must exist alongside the requested architecture.
-    // In these cases, we must select the first item that ends with 'android*', 'ios', or 'wasm*'.
-    const requiresParallelDesktop = qtArchDirs.filter((p) => p.match(/6\.\d+\.\d+\/(android[^/]*|ios|wasm[^/]*)$/));
+    // For Qt6 mobile and wasm installations, and Qt6 Windows on ARM installations,
+    // a standard desktop Qt installation must exist alongside the requested architecture.
+    // In these cases, we must select the first item that ends with 'android*', 'ios', 'wasm*' or 'msvc*_arm64'.
+    const requiresParallelDesktop = qtArchDirs.filter((p) => p.match(/6\.\d+\.\d+\/(android[^/]*|ios|wasm[^/]*|msvc[^/]*_arm64)$/));
     if (requiresParallelDesktop.length) {
         // NOTE: if multiple mobile/wasm installations coexist, this may not select the desired directory
         return requiresParallelDesktop[0];

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -37,11 +37,11 @@ const locateQtArchDir = (installDir: string): string => {
     .sync(`${installDir}/[0-9]*/*/bin/qmake*`)
     .map((s) => s.replace(/\/bin\/qmake[^/]*$/, ""));
 
-  // For Qt6 mobile and wasm installations, a standard desktop Qt installation
-  // must exist alongside the requested architecture.
-  // In these cases, we must select the first item that ends with 'android*', 'ios', or 'wasm*'.
+  // For Qt6 mobile and wasm installations, and Qt6 Windows on ARM installations,
+  // a standard desktop Qt installation must exist alongside the requested architecture.
+  // In these cases, we must select the first item that ends with 'android*', 'ios', 'wasm*' or 'msvc*_arm64'.
   const requiresParallelDesktop = qtArchDirs.filter((p) =>
-    p.match(/6\.\d+\.\d+\/(android[^/]*|ios|wasm[^/]*)$/)
+    p.match(/6\.\d+\.\d+\/(android[^/]*|ios|wasm[^/]*|msvc[^/]*_arm64)$/)
   );
   if (requiresParallelDesktop.length) {
     // NOTE: if multiple mobile/wasm installations coexist, this may not select the desired directory


### PR DESCRIPTION
Windows on ARM also requires a standard desktop Qt installation, however when attempting to use this action with arm, the desktop paths are set instead.

This PR fixes this issue by preferring `msvc*_arm64` versions of Qt (the same way `android*`, `ios` and `wasm*` versions are preferred.