### PR TITLE
Add libxcb-cursor0 to Linux dependencies for Qt 6.5 and up

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -308,9 +308,14 @@ const run = async (): Promise<void> => {
           "libxkbcommon-dev",
           "libxkbcommon-x11-0",
           "libxcb-xkb-dev",
-        ].join(" ");
+        ];
+
+        if (compareVersions(inputs.version, ">=", "6.5.0")) {
+          dependencies.push("libxcb-cursor0");
+        }
+
         const updateCommand = "apt-get update";
-        const installCommand = `apt-get install ${dependencies} -y`;
+        const installCommand = `apt-get install ${dependencies.join(" ")} -y`;
         if (inputs.installDeps === "nosudo") {
           await exec(updateCommand);
           await exec(installCommand);

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -310,6 +310,8 @@ const run = async (): Promise<void> => {
           "libxcb-xkb-dev",
         ];
 
+        // Qt 6.5.0 adds this requirement:
+        // https://code.qt.io/cgit/qt/qtreleasenotes.git/about/qt/6.5.0/release-note.md
         if (compareVersions(inputs.version, ">=", "6.5.0")) {
           dependencies.push("libxcb-cursor0");
         }


### PR DESCRIPTION
Starting Qt 6.5.0, the XCB platform plugin for Linux/X11 also depends on `xcb-cursor0` at runtime, logging as much if the compiled application is started without it being present:

```
from 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin. 
Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```

To resolve this in cases where the application needs to be run within the actions workflow, this PR add the requisite Ubuntu package to the dependency packages installed by the action.