### PR TITLE
Update node.js version to 20; update CI dependencies to remove warnings

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -25,11 +25,11 @@ jobs:
             example-modules:  qtsensors
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
           cache-dependency-path: action/
 

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: action/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
           cache-dependency-path: action/
 
@@ -89,11 +89,11 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 18
           cache: npm
           cache-dependency-path: action/
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: action/
 
@@ -93,7 +93,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           cache: npm
           cache-dependency-path: action/
 

--- a/action.yml
+++ b/action.yml
@@ -83,7 +83,7 @@ runs:
   steps:
   - name: Setup Python 
     if: ${{ inputs.setup-python  == 'true' }}
-    uses: actions/setup-python@v4
+    uses: actions/setup-python@v5
     with:
       python-version: '3.6.x - 3.11.x'
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -76,5 +76,5 @@ inputs:
   example-modules:
     description: Space-separated list of additional example modules to install.
 runs:
-  using: node16
+  using: node20
   main: lib/main.js


### PR DESCRIPTION
This PR completes #219 and fixes #220 .

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3, actions/setup-python@v4, ./action. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
