### PR TITLE
Add 'aqtsource' option that allows overriding where the action sources aqtinstall from

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,12 @@ If you set either `no-qt-binaries` or `tools-only` to `true`, you will skip inst
 
 Default: `false`
 
+### `aqtsource`
+
+The full specifier for a version of [aqtinstall](https://github.com/miurahr/aqtinstall) as passed to pip. For example: `git+https://github.com/miurahr/aqtinstall.git`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall. Note that when this is used, the value of `aqtversion` is ignored.
+
+By default this is unset and ignored.
+
 ### `aqtversion`
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ inputs:
   tools-only:
     description: Synonym for `no-qt-binaries`, used for backwards compatibility.
     default: false
+  aqtsource:
+    description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
     default: ==3.1.*
@@ -105,6 +107,7 @@ runs:
       set-env: ${{ inputs.set-env }}
       no-qt-binaries: ${{ inputs.no-qt-binaries }}
       tools-only: ${{ inputs.tools-only }}
+      aqtsource: ${{ inputs.aqtsource }}
       aqtversion: ${{ inputs.aqtversion }}
       py7zrversion: ${{ inputs.py7zrversion }}
       source: ${{ inputs.source }}

--- a/action/.eslintrc.js
+++ b/action/.eslintrc.js
@@ -57,7 +57,7 @@ module.exports = {
     "@typescript-eslint/no-floating-promises": "error",
     "@typescript-eslint/no-invalid-this": "error",
     "@typescript-eslint/no-loop-func": "error",
-    "@typescript-eslint/no-magic-numbers": ["error", { ignoreArrayIndexes: true }],
+    "@typescript-eslint/no-magic-numbers": ["error", { ignoreArrayIndexes: true, ignore: [0, 1] }],
     "@typescript-eslint/no-redeclare": "error",
     "@typescript-eslint/no-require-imports": "error",
     "@typescript-eslint/no-restricted-imports": "error",

--- a/action/action.yml
+++ b/action/action.yml
@@ -48,6 +48,8 @@ inputs:
   tools-only:
     description: Synonym for `no-qt-binaries`, used for backwards compatibility.
     default: false
+  aqtsource:
+    description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
     default: ==3.1.*

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -108,6 +108,7 @@ class Inputs {
   readonly isInstallQtBinaries: boolean;
   readonly setEnv: boolean;
 
+  readonly aqtSource: string;
   readonly aqtVersion: string;
   readonly py7zrVersion: string;
 
@@ -210,6 +211,7 @@ class Inputs {
 
     this.setEnv = Inputs.getBoolInput("set-env");
 
+    this.aqtSource = core.getInput("aqtsource");
     this.aqtVersion = core.getInput("aqtversion");
 
     this.py7zrVersion = core.getInput("py7zrversion");
@@ -237,6 +239,7 @@ class Inputs {
         this.version,
         this.dir,
         this.py7zrVersion,
+        this.aqtSource,
         this.aqtVersion,
       ],
       this.modules,
@@ -351,7 +354,11 @@ const run = async (): Promise<void> => {
       await execPython("pip install", ["setuptools", "wheel", `"py7zr${inputs.py7zrVersion}"`]);
 
       // Install aqtinstall separately: allows aqtinstall to override py7zr if required
-      await execPython("pip install", [`"aqtinstall${inputs.aqtVersion}"`]);
+      if (inputs.aqtSource.length > 0) {
+        await execPython("pip install", [`"${inputs.aqtSource}"`]);
+      } else {
+        await execPython("pip install", [`"aqtinstall${inputs.aqtVersion}"`]);
+      }
 
       // This flag will install a parallel desktop version of Qt, only where required.
       // aqtinstall will automatically determine if this is necessary.


### PR DESCRIPTION
In the case where upstream aqtinstall breaks, or is somehow inadequate for a particular use case, it's helpful to be able to point the action at a different repository. This change facilitates this, via the new 'aqtsource' option, whose value is passed directly to pip install when set. When unset the usual aqtinstall+$aqtversion value is used.