### PR TITLE
Add missing tool paths to the PATH

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,7 +211,7 @@ jobs:
         uses: ./
         with:
           tools-only: true
-          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator tools_cmake tools_ninja tools_conan
           add-tools-to-path: ${{ matrix.qt.add-tools-to-path }}
           cache: ${{ matrix.cache == 'cached' }}
 
@@ -220,26 +220,45 @@ jobs:
         shell: bash
         run: |
           echo "Path: ${PATH}"
-          # Check if QtIFW is installed
-          which archivegen
-          archivegen --version
-  
-          # Check if QtCreator is installed: QtCreator includes the CLI program 'qbs' on all 3 platforms
-          which qbs
-          qbs --version
+          set -x
+
+          # tools_ifw: use `archivegen` to test that Tools/QtInstallerFramework/4.7/bin is added to path
+          # tools_qtcreator: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is added to path
+          # tools_cmake: test that Tools/CMake/bin or Tools/CMake/CMake.app/Contents/bin is added to path
+          # tools_ninja: test that Tools/Ninja is added to path
+          # tools_conan: test that Tools/Conan is added to path
+
+          for tool_name in archivegen qbs cmake ninja conan; do
+            which "${tool_name}"
+            "${tool_name}" --version
+          done
+          
 
       - name: Test that installed tools are not in the path
         if: ${{ matrix.qt.tools-only-build && !matrix.qt.add-tools-to-path }}
         shell: bash
         run: |
           echo "Path: ${PATH}"
+          set -x
+
           # Check that QtIFW has been installed
           ls ../Qt/Tools/QtInstallerFramework/*/bin/ | grep archivegen
-          
-          # Check that QtIFW is not in the path
-          ! which archivegen
-          ! archivegen --version
-          
-          # Check that qbs (from QtCreator) is not in the path
-          ! which qbs
-          ! qbs --version
+          # Check that QtCreator has been installed
+          [[ -e "../Qt/Tools/QtCreator/bin/qbs" || -e "../Qt/Qt Creator.app/Contents/MacOS/qbs" ]]
+          # Check that CMake has been installed
+          [[ -e "../Qt/Tools/CMake/bin/cmake" || -e "../Qt/Tools/CMake/CMake.app/Contents/bin/cmake" ]]
+          # Check that Ninja has been installed
+          [[ -e "../Qt/Tools/Ninja/ninja" ]]
+          # Check that Conan has been installed
+          [[ -e "../Qt/Tools/Conan/conan" ]]
+
+          # tools_ifw: use `archivegen` to test that Tools/QtInstallerFramework/4.7/bin is not added to path
+          # tools_qtcreator: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is not added to path
+          # tools_cmake: test that Tools/CMake/bin or Tools/CMake/CMake.app/Contents/bin is not added to path
+          # tools_ninja: test that Tools/Ninja is not added to path
+          # tools_conan: test that Tools/Conan is not added to path
+
+          for tool_name in archivegen qbs cmake ninja conan; do
+            ! which "${tool_name}"
+            ! "${tool_name}" --version
+          done


### PR DESCRIPTION
Fix #255.

This PR fixes the behavior of the `add-tools-to-path` option for a few tools where it currently does not work. These tools include:
* Ninja: this tool installs at `Tools/Ninja/ninja`
* Conan: this tool installs at `Tools/Conan/conan`
* CMake: On MacOS, this tool installs at `Tools/CMake/CMake.app`, which is not where `install-qt-action` currently looks for it, parallel to the `Tools` directory.

This PR also adds tests to check that these tools are installed, executable, and in the PATH when `add-tools-to-path` is set.

It is still possible that there are other tools somewhere in the Qt repo that aren't being added to the PATH properly; I have not exhaustively searched them. If there are more such tools, it should not be too difficult to modify this code to fix them.