### PR TITLE
Ability to use msvc2022 for Qt 6.7.3

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -186,7 +186,7 @@ class Inputs {
           this.arch = "android_armv7";
         }
       } else if (this.host === "windows") {
-        if (compareVersions(this.version, ">=", "6.8.0")) {
+        if (compareVersions(this.version, ">=", "6.7.3")) {
           this.arch = "win64_msvc2022_64";
         } else if (compareVersions(this.version, ">=", "5.15.0")) {
           this.arch = "win64_msvc2019_64";


### PR DESCRIPTION
I propose a small change so that Qt 6.7.3 can use msvc2022. This will not prevent Qt 6.8.0 from using msvc2022.