### PR TITLE
Revert "Use msvc2022 for Qt 6.7.3"

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -186,7 +186,7 @@ class Inputs {
           this.arch = "android_armv7";
         }
       } else if (this.host === "windows") {
-        if (compareVersions(this.version, ">=", "6.7.3")) {
+        if (compareVersions(this.version, ">=", "6.8.0")) {
           this.arch = "win64_msvc2022_64";
         } else if (compareVersions(this.version, ">=", "5.15.0")) {
           this.arch = "win64_msvc2019_64";


### PR DESCRIPTION
This reverts commit b9760ab01f548abc52e3649b6ec31dbecfe229d0 (https://github.com/jurplel/install-qt-action/pull/257).

`aqtinstall` doesn't provide a `win64_msvc2022_64`:

```console
> aqt list-qt windows desktop --arch 6.7.3
win64_llvm_mingw win64_mingw win64_msvc2019_64 win64_msvc2019_arm64
```
