### PR TITLE
Update deprecated macOS-12 to macOS-15

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -11,7 +11,7 @@ jobs:
         os:
           - ubuntu-22.04
           - windows-2022
-          - macos-12
+          - macos-15
         qt:
           - version: "5.15.2"
             ndk-version: r21e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,9 @@ jobs:
           - ubuntu-20.04
           - windows-2022
           - windows-2019
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
         aqtversion:
           - null  # use whatever the default is
         src-doc-examples:


### PR DESCRIPTION
MacOS-12 images are deprecated and will be removed next month.

See https://github.com/actions/runner-images/issues/10721 for details.