### PR TITLE
Use path library for path manipulation 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,14 @@ jobs:
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
           cache: ${{ matrix.cache == 'cached' }}
 
+      - name: Test QT_ROOT_DIR
+        if: ${{ matrix.qt.version }}
+        shell: bash
+        run: |
+          set -x
+          # Check that QT_ROOT_DIR contains a qmake of some kind
+          ls "${QT_ROOT_DIR}/bin/" | grep qmake
+
       - name: Switch macOS Xcode version with older Qt versions
         if: ${{ matrix.qt.version && (startsWith(matrix.os, 'macos-13') || startsWith(matrix.os, 'macos-14')) }}
         shell: pwsh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,6 +60,12 @@ jobs:
           - cached
           - uncached
         include:
+          - os: windows-latest
+            dir: '/'
+            qt:
+              version: "6.7.0"
+              requested: "6.7.0"
+              modules: qtwebengine qtpositioning qtwebchannel
           - os: ubuntu-20.04
             src-doc-examples: true
             source: true
@@ -114,6 +120,7 @@ jobs:
         if: ${{ !matrix.aqtversion && matrix.qt.version }}
         uses: ./
         with:
+          dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
@@ -124,6 +131,7 @@ jobs:
         uses: ./
         with:
           aqtversion: ${{ matrix.aqtversion }}
+          dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
@@ -174,6 +182,7 @@ jobs:
         if: ${{ matrix.source }}
         uses: ./
         with:
+          dir: ${{ matrix.dir }}
           version: "5.15.2"
           source: true
           no-qt-binaries: true
@@ -183,6 +192,7 @@ jobs:
         if: ${{ matrix.documentation }}
         uses: ./
         with:
+          dir: ${{ matrix.dir }}
           version: "5.15.2"
           documentation: true
           no-qt-binaries: true
@@ -193,6 +203,7 @@ jobs:
         if: ${{ matrix.examples }}
         uses: ./
         with:
+          dir: ${{ matrix.dir }}
           version: "5.15.2"
           examples: true
           no-qt-binaries: true
@@ -210,6 +221,7 @@ jobs:
         if: ${{ matrix.qt.tools-only-build }}
         uses: ./
         with:
+          dir: ${{ matrix.dir }}
           tools-only: true
           tools: tools_ifw tools_qtcreator,qt.tools.qtcreator tools_cmake tools_ninja tools_conan
           add-tools-to-path: ${{ matrix.qt.add-tools-to-path }}

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -11,8 +11,6 @@ import { exec, getExecOutput } from "@actions/exec";
 import * as glob from "glob";
 import { compare, CompareOperator } from "compare-versions";
 
-const nativePath = process.platform === "win32" ? path.win32.normalize : path.normalize;
-
 const compareVersions = (v1: string, op: CompareOperator, v2: string): boolean => {
   return compare(v1, v2, op);
 };
@@ -50,7 +48,8 @@ const toolsPaths = (installDir: string): string[] => {
     "Tools/*/*.app/**/bin",
   ]
     .flatMap((p: string): string[] => glob.sync(`${installDir}/${p}`))
-    .concat(binlessPaths);
+    .concat(binlessPaths)
+    .map((p) => path.resolve(p));
 };
 
 const pythonCommand = (command: string, args: readonly string[]): string => {
@@ -77,7 +76,7 @@ const locateQtArchDir = (installDir: string): string => {
   // This makes a list of all the viable arch directories that contain a qmake file.
   const qtArchDirs = glob
     .sync(`${installDir}/[0-9]*/*/bin/qmake*`)
-    .map((s) => path.join(s, "..", ".."));
+    .map((s) => path.resolve(s, "..", ".."));
 
   // For Qt6 mobile and wasm installations, and Qt6 Windows on ARM installations,
   // a standard desktop Qt installation must exist alongside the requested architecture.
@@ -206,7 +205,7 @@ class Inputs {
     if (!dir) {
       throw TypeError(`"dir" input may not be empty`);
     }
-    this.dir = path.join(dir, "Qt");
+    this.dir = path.resolve(dir, "Qt");
 
     this.modules = Inputs.getStringArrayInput("modules");
 
@@ -447,35 +446,35 @@ const run = async (): Promise<void> => {
 
   // Add tools to path
   if (inputs.addToolsToPath && inputs.tools.length) {
-    toolsPaths(inputs.dir).map(nativePath).forEach(core.addPath);
+    toolsPaths(inputs.dir).forEach(core.addPath);
   }
 
   // Set environment variables/outputs for tools
   if (inputs.tools.length && inputs.setEnv) {
-    core.exportVariable("IQTA_TOOLS", nativePath(path.join(inputs.dir, "Tools")));
+    core.exportVariable("IQTA_TOOLS", path.resolve(inputs.dir, "Tools"));
   }
   // Set environment variables/outputs for binaries
   if (inputs.isInstallQtBinaries) {
-    const qtPath = nativePath(locateQtArchDir(inputs.dir));
+    const qtPath = locateQtArchDir(inputs.dir);
     // Set outputs
     core.setOutput("qtPath", qtPath);
 
     // Set env variables
     if (inputs.setEnv) {
       if (process.platform === "linux") {
-        setOrAppendEnvVar("LD_LIBRARY_PATH", nativePath(path.join(qtPath, "lib")));
+        setOrAppendEnvVar("LD_LIBRARY_PATH", path.resolve(qtPath, "lib"));
       }
       if (process.platform !== "win32") {
-        setOrAppendEnvVar("PKG_CONFIG_PATH", nativePath(path.join(qtPath, "lib", "pkgconfig")));
+        setOrAppendEnvVar("PKG_CONFIG_PATH", path.resolve(qtPath, "lib", "pkgconfig"));
       }
       // If less than qt6, set Qt5_DIR variable
       if (compareVersions(inputs.version, "<", "6.0.0")) {
-        core.exportVariable("Qt5_DIR", nativePath(path.join(qtPath, "lib", "cmake")));
+        core.exportVariable("Qt5_DIR", path.resolve(qtPath, "lib", "cmake"));
       }
       core.exportVariable("QT_ROOT_DIR", qtPath);
-      core.exportVariable("QT_PLUGIN_PATH", nativePath(path.join(qtPath, "plugins")));
-      core.exportVariable("QML2_IMPORT_PATH", nativePath(path.join(qtPath, "qml")));
-      core.addPath(nativePath(path.join(qtPath, "bin")));
+      core.exportVariable("QT_PLUGIN_PATH", path.resolve(qtPath, "plugins"));
+      core.exportVariable("QML2_IMPORT_PATH", path.resolve(qtPath, "qml"));
+      core.addPath(path.resolve(qtPath, "bin"));
     }
   }
 };


### PR DESCRIPTION
Fix #259.

Currently, this action relies heavily on string manipulation techniques to compose paths. This approach is prone to error, particularly in the context of Windows and inconsistent use of native path delimiters. This PR uses the standard Node `path` library to manipulate paths.

* Link to test run that replicates #259, using the install directory `/` and test runner `windows-latest`: https://github.com/ddalcino/install-qt-action/actions/runs/11786060831/job/32828603078#step:9:1
  Note the broken environment variables:
  ```
  IQTA_TOOLS: \\Qt\Tools\
  QT_ROOT_DIR: D:\Qt\6.7.0\msvc2019_64\bin\qmake.exe
  QT_PLUGIN_PATH: D:\Qt\6.7.0\msvc2019_64\bin\qmake.exe\plugins
  QML2_IMPORT_PATH: D:\Qt\6.7.0\msvc2019_64\bin\qmake.exe\qml
  ```
* Link to failing test run that explicitly checks the `QT_ROOT_DIR` variable: https://github.com/ddalcino/install-qt-action/actions/runs/11786135722/job/32828835488#step:8:1
* Link to passing test run, with environment identical to the failing runs, after the fix is applied: https://github.com/ddalcino/install-qt-action/actions/runs/11786675815/job/32830453747#step:8:1
  Note the fixed environment variables:
  ```
  IQTA_TOOLS: \Qt\Tools
  QT_ROOT_DIR: D:\Qt\6.7.0\msvc2019_64
  QT_PLUGIN_PATH: D:\Qt\6.7.0\msvc2019_64\plugins
  QML2_IMPORT_PATH: D:\Qt\6.7.0\msvc2019_64\qml
  ```
* Since 485d851a8e2f550d8ed45c53bc8488d51711f2b0 (use `path.resolve` instead of `path.join`), `IQTA_TOOLS` now has a drive letter: https://github.com/jurplel/install-qt-action/actions/runs/11788985029/job/32836995662?pr=266#step:8:1
  ```
  IQTA_TOOLS: D:\Qt\Tools
  QT_ROOT_DIR: D:\Qt\6.7.0\msvc2019_64
  QT_PLUGIN_PATH: D:\Qt\6.7.0\msvc2019_64\plugins
  QML2_IMPORT_PATH: D:\Qt\6.7.0\msvc2019_64\qml
  ```