### PR TITLE
Adjust `python-version` limits

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '3.6.x - 3.11.x'
+      python-version: '>=3.9.x'
 
   - name: Setup and run aqtinstall
     uses: ./action


### PR DESCRIPTION
Changed range ('3.6.x - 3.11.x') of `python-version` to `>=3.9`
* This is the Minimum requirement of [`aqtinstall`](https://github.com/miurahr/aqtinstall?tab=readme-ov-file#requirements)
* Allows the use of higher Python versions available on the associated "GitHub Actions Runner Images" being used.
* "GitHub Actions Runner Images" will have various Python versions removed/in-process of removing [Example 1](https://github.com/actions/runner-images/issues/10893), [Example 2](https://github.com/actions/runner-images/issues/10812)
____

**NOTE:**
Xcode failures are due to `Xcode 14` no longer being available on macOS-14 runner images
See: https://github.com/actions/runner-images/issues/10703