### PR TITLE
Set QT_HOST_PATH for parallel desktop installations

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -52,6 +52,22 @@ jobs:
           example-archives: ${{ matrix.qt.example-archives }}
           example-modules:  ${{ matrix.qt.example-modules }}
 
+      - name: Test QT_HOST_PATH
+        if: ${{ startsWith(matrix.qt.version, '6.') }}
+        shell: pwsh
+        run: |
+          $qmakeHostPrefix = [string](Resolve-Path -Path (qmake -query QT_HOST_PREFIX))
+          if ($env:QT_HOST_PATH -ne $qmakeHostPrefix) {
+            throw "QT_HOST_PATH should match qmake's QT_HOST_PREFIX."
+          }
+          if ($env:QT_HOST_PATH -eq $env:QT_ROOT_DIR) {
+            throw "QT_HOST_PATH and QT_ROOT_DIR should be different."
+          }
+          if ((Split-Path -Path $env:QT_HOST_PATH -Parent) -ne (Split-Path -Path $env:QT_ROOT_DIR -Parent)) {
+            throw "QT_HOST_PATH and QT_ROOT_DIR should have the same parent directory."
+          }
+          Write-Host "All tests passed!"
+
       - name: Install Android NDK
         shell: bash
         # Links to NDK are at https://github.com/android/ndk/wiki/Unsupported-Downloads

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,17 +146,14 @@ jobs:
           ls "${QT_ROOT_DIR}/bin/" | grep qmake
 
       - name: Switch macOS Xcode version with older Qt versions
-        if: ${{ matrix.qt.version && (startsWith(matrix.os, 'macos-13') || startsWith(matrix.os, 'macos-14')) }}
+        if: ${{ matrix.qt.version && startsWith(matrix.os, 'macos-13') }}
         shell: pwsh
         env:
           QT_VERSION: ${{ matrix.qt.version }}
         run: |
-          if ([version]$env:QT_VERSION -ge [version]"6.5.3") {
-              # GitHub macOS 13/14 runners use Xcode 15.0.x by default which has a known linker issue causing crashes if the artifact is run on macOS <= 12
-              sudo xcode-select --switch /Applications/Xcode_15.2.app
-          } else {
-              # Keep older Qt versions on Xcode 14 due to concern over QTBUG-117484
-              sudo xcode-select --switch /Applications/Xcode_14.3.1.app
+          if ([version]$env:QT_VERSION -lt [version]'6.5.3') {
+            # Workaround for QTBUG-117225
+            sudo xcode-select --switch /Applications/Xcode_14.3.1.app
           }
 
       - name: Configure test project on windows

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -84,7 +84,9 @@ const locateQtArchDir = (installDir: string): [string, boolean] => {
   const requiresParallelDesktop = qtArchDirs.filter((archPath) => {
     const archDir = path.basename(archPath);
     const versionDir = path.basename(path.join(archPath, ".."));
-    return versionDir.match(/^6\.\d+\.\d+$/) && archDir.match(/^(android.*|ios|wasm.*|msvc.*_arm64)$/);
+    return (
+      versionDir.match(/^6\.\d+\.\d+$/) && archDir.match(/^(android.*|ios|wasm.*|msvc.*_arm64)$/)
+    );
   });
   if (requiresParallelDesktop.length) {
     // NOTE: if multiple mobile/wasm installations coexist, this may not select the desired directory

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -478,8 +478,10 @@ const run = async (): Promise<void> => {
       core.exportVariable("QML2_IMPORT_PATH", path.resolve(qtPath, "qml"));
       if (requiresParallelDesktop) {
         const qmakePath = path.resolve(qtPath, "bin", "qmake");
-        const queryResult = await getExecOutput(`${qmakePath} -query QT_HOST_PREFIX`);
-        core.exportVariable("QT_HOST_PATH", path.normalize(queryResult.stdout.trim()));
+        const val = await getExecOutput(`${qmakePath} -query QT_HOST_PREFIX`).catch(() => null);
+        if (val?.exitCode === 0) {
+          core.exportVariable("QT_HOST_PATH", path.normalize(val.stdout.trim()));
+        }
       }
       core.addPath(path.resolve(qtPath, "bin"));
     }

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -477,10 +477,12 @@ const run = async (): Promise<void> => {
       core.exportVariable("QT_PLUGIN_PATH", path.resolve(qtPath, "plugins"));
       core.exportVariable("QML2_IMPORT_PATH", path.resolve(qtPath, "qml"));
       if (requiresParallelDesktop) {
-        const qmakePath = path.resolve(qtPath, "bin", "qmake");
-        const val = await getExecOutput(`${qmakePath} -query QT_HOST_PREFIX`).catch(() => null);
-        if (val?.exitCode === 0) {
-          core.exportVariable("QT_HOST_PATH", path.normalize(val.stdout.trim()));
+        const hostPrefix = await fs.promises
+          .readFile(path.join(qtPath, "bin", "target_qt.conf"), "utf8")
+          .then((data) => data.match(/^HostPrefix=(.*)$/m)?.[1].trim() ?? "")
+          .catch(() => "");
+        if (hostPrefix) {
+          core.exportVariable("QT_HOST_PATH", path.resolve(qtPath, "bin", hostPrefix));
         }
       }
       core.addPath(path.resolve(qtPath, "bin"));

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -84,7 +84,7 @@ const locateQtArchDir = (installDir: string): string => {
   const requiresParallelDesktop = qtArchDirs.filter((archPath) => {
     const archDir = path.basename(archPath);
     const versionDir = path.basename(path.join(archPath, ".."));
-    return versionDir.match(/^6\.\d+\.\d+$/) && archDir.match(/^(android*|ios|wasm*|msvc*_arm64)$/);
+    return versionDir.match(/^6\.\d+\.\d+$/) && archDir.match(/^(android.*|ios|wasm.*|msvc.*_arm64)$/);
   });
   if (requiresParallelDesktop.length) {
     // NOTE: if multiple mobile/wasm installations coexist, this may not select the desired directory


### PR DESCRIPTION
Qt wants `QT_HOST_PATH` when cross-compiling with CMake ([docs](https://doc.qt.io/qt-6/cmake-variable-qt-host-path.html), and [relevant code](https://github.com/qt/qtbase/blob/6.8.1/cmake/QtPublicDependencyHelpers.cmake#L275) to prove it reads the environment variable), and one needs to know this path in other cases like running `windeployqt` since it's only present in the host's installation.

I also fixed a regression introduced in 7595e10a17ba076a16a0354ea11c70a0705836a6, where the regex was changed from something like:
`msvc[^/]*_arm64`
To:
`msvc*_arm64`

Before, `*` applied to the preceding `[^/]`, meaning to match 0 or more non-slash characters. The regression made it look for 0 or more `c` characters (followed immediately by an underscore), so it wouldn't be able to match `msvc2022_arm64` for example.

You can see my commit in a test project [here](https://github.com/jdpurcell/QtHelloWorld/commit/f65122386772d3b8772434b44d45c1ce58b2623a) where I was able to rely on install-qt-action setting the environment variable instead of doing it in my PowerShell script. Examining the corresponding log from the [actions run](https://github.com/jdpurcell/QtHelloWorld/actions/runs/12267797655/job/34228529842), one can see that the `QT_HOST_PATH` environment variable is already set properly prior to entering the Build step.

<img width="653" alt="image" src="https://github.com/user-attachments/assets/fc9c7993-35a1-431b-bd7a-5c5395b265cd">
