### PR TITLE
To fix issues with Qt 6.7+ and match with aqtinstall, allows 'all_os' for host and 'wasm' for target

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This is the host platform of the Qt version you will be installing. It's unlikel
 
 For example, if you are building on Linux and targeting desktop, you would set host to `linux`. If you are building on Linux and targeting android, you would set host to `linux` also. The host platform is the platform that your application will build on, not its target platform.
 
-Possible values: `windows`, `mac`, or `linux`
+Possible values: `windows`, `mac`, `linux` or `all_os`
 
 Defaults to the current platform it is being run on.
 
 ### `target`
 This is the target platform that you will be building for. You will want to set this if you are building for iOS or Android. Please note that iOS builds are supported only on macOS hosts and Win RT builds are only supported on Windows hosts.
 
-Possible values: `desktop`, `android`, `ios`, or `winrt`
+Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`
 
 Default: `desktop`
 
@@ -65,6 +65,8 @@ Windows w/ Qt >= 5.15 && Qt < 6.8: `win64_msvc2019_64`
 Windows w/ Qt >= 6.8: `win64_msvc2022_64`
 
 Android: `android_armv7`
+
+WASM: `wasm_singlethread`
 
 ### `dir`
 This is the directory prefix that Qt will be installed to.
@@ -255,8 +257,11 @@ Default: `==0.20.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
+It is useful with WASM builds using `--autodesktop` as it allows the automatic installation of the required Qt for the host.
 
 Example value: `--external 7z`
+
+For WASM: `--autodesktop`
 
 ## Example with all arguments
 

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -104,8 +104,8 @@ const isAutodesktopSupported = async (): Promise<boolean> => {
 };
 
 class Inputs {
-  readonly host: "windows" | "mac" | "linux";
-  readonly target: "desktop" | "android" | "ios";
+  readonly host: "windows" | "mac" | "linux" | "all_os";
+  readonly target: "desktop" | "android" | "ios" | "wasm";
   readonly version: string;
   readonly arch: string;
   readonly dir: string;
@@ -156,19 +156,19 @@ class Inputs {
       }
     } else {
       // Make sure host is one of the allowed values
-      if (host === "windows" || host === "mac" || host === "linux") {
+      if (host === "windows" || host === "mac" || host === "linux" || host === "all_os") {
         this.host = host;
       } else {
-        throw TypeError(`host: "${host}" is not one of "windows" | "mac" | "linux"`);
+        throw TypeError(`host: "${host}" is not one of "windows" | "mac" | "linux" | "all_os"`);
       }
     }
 
     const target = core.getInput("target");
     // Make sure target is one of the allowed values
-    if (target === "desktop" || target === "android" || target === "ios") {
+    if (target === "desktop" || target === "android" || target === "ios" || target === "wasm") {
       this.target = target;
     } else {
-      throw TypeError(`target: "${target}" is not one of "desktop" | "android" | "ios"`);
+      throw TypeError(`target: "${target}" is not one of "desktop" | "android" | "ios" | "wasm"`);
     }
 
     // An attempt to sanitize non-straightforward version number input
@@ -185,6 +185,12 @@ class Inputs {
           this.arch = "android";
         } else {
           this.arch = "android_armv7";
+        }
+      } else if (this.target === "wasm") {
+        if (compareVersions(this.version, ">=", "6.0.0")) {
+          this.arch = "wasm_singlethread";
+        } else {
+          this.arch = "wasm_32";
         }
       } else if (this.host === "windows") {
         if (compareVersions(this.version, ">=", "6.8.0")) {


### PR DESCRIPTION
Since Qt 6.7+, the Qt team decided to make WASM a part of `all_os` as host, with target `wasm`. This is sensible as the WASM version of Qt cannot work on its own and needs a host. To install Qt WASM for the latest versions, it will soon be required to use the action like this:
```
- name: Install Qt for host and WASM
  uses: jurplel/install-qt-action@v4.1.1
  with:
    version: '6.8.1'
    host: 'all_os'
    target: 'wasm'
    arch: 'wasm_singlethread'
    modules: 'all'
    extra: '--autodesktop'
```

> [!NOTE]
> The `extra: '--autodesktop'` part is important, as it will automatically install the correct Qt for your host along with WASM. You can also install it in another block if you want, like before. 
> Maybe a `autodesktop: true` parameter could be beneficial.

This change will be required [once this PR goes through](https://github.com/miurahr/aqtinstall/pull/846), but it is not breaking anything until it does get merged