### PR TITLE
Add commercial support, fix WASM and issues with Qt 6.7.+

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,11 +257,8 @@ Default: `==0.20.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
-It is useful with WASM builds using `--autodesktop` as it allows the automatic installation of the required Qt for the host.
 
 Example value: `--external 7z`
-
-For WASM: `--autodesktop`
 
 ## Example with all arguments
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in SimpleSpec version numbers, for example `6.2.*`.
 
-Default: `5.15.2` (Last Qt 5 LTS)
+Default: `6.8.1` (Last Qt 6 LTS)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -65,8 +65,6 @@ Windows w/ Qt >= 5.15 && Qt < 6.8: `win64_msvc2019_64`
 Windows w/ Qt >= 6.8: `win64_msvc2022_64`
 
 Android: `android_armv7`
-
-WASM: `wasm_singlethread`
 
 ### `dir`
 This is the directory prefix that Qt will be installed to.
@@ -248,7 +246,7 @@ By default this is unset and ignored.
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `==3.1.*`
+Default: `==3.2.*`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
@@ -266,10 +264,10 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '5.15.2'
+        version: '6.8.1'
         host: 'windows'
         target: 'desktop'
-        arch: 'win64_msvc2019_64'
+        arch: 'win64_msvc2022_64'
         dir: '${{ github.workspace }}/example/'
         install-deps: 'true'
         modules: 'qtcharts qtwebengine'
@@ -280,7 +278,7 @@ Example value: `--external 7z`
         tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'true'
         tools-only: 'false'
-        aqtversion: '==3.1.*'
+        aqtversion: '==3.2.*'
         py7zrversion: '==0.20.*'
         extra: '--external 7z'
 ```

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ This is the host platform of the Qt version you will be installing. It's unlikel
 
 For example, if you are building on Linux and targeting desktop, you would set host to `linux`. If you are building on Linux and targeting android, you would set host to `linux` also. The host platform is the platform that your application will build on, not its target platform.
 
-Possible values: `windows`, `mac`, or `linux`
+Possible values: `windows`, `mac`, `linux` or `all_os`
 
 Defaults to the current platform it is being run on.
 
 ### `target`
 This is the target platform that you will be building for. You will want to set this if you are building for iOS or Android. Please note that iOS builds are supported only on macOS hosts and Win RT builds are only supported on Windows hosts.
 
-Possible values: `desktop`, `android`, `ios`, or `winrt`
+Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`
 
 Default: `desktop`
 
@@ -65,6 +65,8 @@ Windows w/ Qt >= 5.15 && Qt < 6.8: `win64_msvc2019_64`
 Windows w/ Qt >= 6.8: `win64_msvc2022_64`
 
 Android: `android_armv7`
+
+WASM: `wasm_singlethread`
 
 ### `dir`
 This is the directory prefix that Qt will be installed to.
@@ -255,8 +257,11 @@ Default: `==0.20.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
+It is useful with WASM builds using `--autodesktop` as it allows the automatic installation of the required Qt for the host.
 
 Example value: `--external 7z`
+
+For WASM: `--autodesktop`
 
 ## Example with all arguments
 

--- a/README.md
+++ b/README.md
@@ -74,9 +74,9 @@ When possible, access your Qt directory through the `QT_ROOT_DIR` environment va
 
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
-### `use-commercial` (since `v4.3.0`)
-Whether or not to use `aqtinstall` to install Qt using its official online installer enabling the commercial versions for those owning a license.
-For this to work, you need to also set `aqtsource` to `git+https://github.com/Kidev/aqtinstall.git@install_qt_commercial`.
+### `use-official` (since `v4.3.0`)
+Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions 
+for those owning a license).
 The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.
 Example:
 ```yml
@@ -87,18 +87,18 @@ Example:
         target: 'desktop'
         arch: 'win64_msvc2019_64'
         aqtsource: 'git+https://github.com/Kidev/aqtinstall.git@install_qt_commercial'
-        use-commercial: true
-        user: '****@gmail.com'
-        password: '****'
+        use-official: true
+        email: '****@gmail.com'
+        pw: '****'
 ```
 
 Default: `false`
 
-#### `user`
-If `use-commercial` is true, will use this username/email to authenticate with Qt servers
+#### `email`
+If `use-official` is true, will use this username/email to authenticate with Qt servers
 
-#### `password`
-If `use-commercial` is true, will use this password to authenticate with Qt servers
+#### `pw`
+If `use-official` is true, will use this password to authenticate with Qt servers
 
 ### `install-deps`
 Whether or not to automatically install Qt dependencies on Linux through `apt`.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in SimpleSpec version numbers, for example `6.2.*`.
 
-Default: `6.8.3` (Last Qt 6 LTS)
+Default: `6.8.2` (Last Qt 6 LTS)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -85,7 +85,7 @@ Example:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.3'
+        version: '6.8.2'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
         use-official: true
@@ -293,7 +293,7 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.3'
+        version: '6.8.2'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in SimpleSpec version numbers, for example `6.2.*`.
 
-Default: `6.8.2` (Last Qt 6 LTS)
+Default: `6.8.3` (Last Qt 6 LTS)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -32,16 +32,21 @@ This is the host platform of the Qt version you will be installing. It's unlikel
 
 For example, if you are building on Linux and targeting desktop, you would set host to `linux`. If you are building on Linux and targeting android, you would set host to `linux` also. The host platform is the platform that your application will build on, not its target platform.
 
-Possible values: `windows`, `mac`, `linux` or `all_os`
+Possible values: `windows`, `mac`, `linux` or `all_os`_
+`all_os` is incompatible with `aqtinstall < 3.2.0`._
 
-Defaults to the current platform it is being run on.
+Defaults to the current platform it is being run on._
+
 
 ### `target`
 This is the target platform that you will be building for. You will want to set this if you are building for iOS or Android. Please note that iOS builds are supported only on macOS hosts and Win RT builds are only supported on Windows hosts.
 
-Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`
+Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`_
+`wasm` is incompatible with `aqtinstall < 3.2.0`._
 
 Default: `desktop`
+
+
 
 ### `arch`
 This is the target architecture that your program will be built for.
@@ -74,9 +79,8 @@ When possible, access your Qt directory through the `QT_ROOT_DIR` environment va
 
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
-### `use-official` (since `v4.2.0`)
-Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions 
-for those owning a license).
+### `use-official` (since `v4.2.*`)
+Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions for those owning a license). Incompatible with `aqtinstall < 3.2.1`._
 The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.  
 You should use secrets, and store the fields `email` and `pw` inside `QT_EMAIL` and `QT_PW` for example to match the example below.  
 
@@ -85,7 +89,7 @@ Example:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.2'
+        version: '6.8.3'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
         use-official: true
@@ -96,11 +100,11 @@ Example:
 Default: `false`
 
 #### `email`
-If `use-official` is true, will use this username/email to authenticate with Qt servers.  
+If `use-official` is true, will use this username/email to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`._
 You should use secrets, and store the value inside `QT_EMAIL` for example to match the example above.
 
 #### `pw`
-If `use-official` is true, will use this password to authenticate with Qt servers.  
+If `use-official` is true, will use this password to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`._
 You should use secrets, and store the value inside `QT_PW` for example to match the example above.
 
 ### `install-deps`
@@ -275,12 +279,12 @@ By default this is unset and ignored.
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `>=3.2.1`
+Default: `==3.2.*`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
 
-Default: `==0.20.*`
+Default: `==0.22.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
@@ -293,7 +297,7 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.2'
+        version: '6.8.3'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
@@ -307,8 +311,8 @@ Example value: `--external 7z`
         tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'true'
         tools-only: 'false'
-        aqtversion: '>=3.2.1'
-        py7zrversion: '==0.20.*'
+        aqtversion: '==3.2.*'
+        py7zrversion: '==0.22.*'
         extra: '--external 7z'
         use-official: false
         email: ${{ secrets.QT_EMAIL }}

--- a/README.md
+++ b/README.md
@@ -77,15 +77,17 @@ Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 ### `use-official` (since `v4.2.0`)
 Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions 
 for those owning a license).
-The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.
+The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.  
+You should use secrets, and store the fields `email` and `pw` inside `QT_EMAIL` and `QT_PW` for example to match the example below.  
+
 Example:
 ```yml
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '5.15.3'
+        version: '6.8.3'
         target: 'desktop'
-        arch: 'win64_msvc2019_64'
+        arch: 'win64_msvc2022_64'
         use-official: true
         email: ${{ secrets.QT_EMAIL }}
         pw: ${{ secrets.QT_PW }}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in SimpleSpec version numbers, for example `6.2.*`.
 
-Default: `6.8.1` (Last Qt 6 LTS)
+Default: `6.8.3` (Last Qt 6 LTS)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -74,7 +74,7 @@ When possible, access your Qt directory through the `QT_ROOT_DIR` environment va
 
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
-### `use-official` (since `v4.3.0`)
+### `use-official` (since `v4.2.0`)
 Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions 
 for those owning a license).
 The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.
@@ -94,10 +94,12 @@ Example:
 Default: `false`
 
 #### `email`
-If `use-official` is true, will use this username/email to authenticate with Qt servers
+If `use-official` is true, will use this username/email to authenticate with Qt servers.  
+You should use secrets, and store the value inside `QT_EMAIL` for example to match the example above.
 
 #### `pw`
-If `use-official` is true, will use this password to authenticate with Qt servers
+If `use-official` is true, will use this password to authenticate with Qt servers.  
+You should use secrets, and store the value inside `QT_PW` for example to match the example above.
 
 ### `install-deps`
 Whether or not to automatically install Qt dependencies on Linux through `apt`.
@@ -271,7 +273,7 @@ By default this is unset and ignored.
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `==3.2.*`
+Default: `>=3.2.1`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
@@ -289,7 +291,7 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.1'
+        version: '6.8.3'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
@@ -303,9 +305,12 @@ Example value: `--external 7z`
         tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'true'
         tools-only: 'false'
-        aqtversion: '==3.2.*'
+        aqtversion: '>=3.2.1'
         py7zrversion: '==0.20.*'
         extra: '--external 7z'
+        use-official: false
+        email: ${{ secrets.QT_EMAIL }}
+        pw: ${{ secrets.QT_PW }}
 ```
 
 ## More info
@@ -317,7 +322,7 @@ On MacOS, if the tool is an app bundle, then the `.app/Contents/MacOS` folder wi
 
 The Qt bin directory is appended to your `path` environment variable.
 `Qt5_DIR` is also set appropriately for CMake if you are using Qt 5.
-In addition, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set accordingly. `IQTA_TOOLS` is set to the "Tools" directory if tools are installed as well.
+In addition, `QT_PLUGIN_PATH`, `QML2_IMPORT_PATH`, `PKG_CONFIG_PATH` and `LD_LIBRARY_PATH` are set accordingly. `IQTA_TOOLS` is set to the "Tools" directory if tools are installed as well. `QT_HOST_PATH` is set if appropriate (WASM).
 
 Since the Qt bin directory is in your `path`, you will not need to set the `CMAKE_PREFIX_PATH` CMake variable.
 If you wish to do so, you can set it to either `${QT_ROOT_DIR}` or to `${QT_ROOT_DIR}/lib/cmake`.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,32 @@ When possible, access your Qt directory through the `QT_ROOT_DIR` environment va
 
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
+### `use-commercial` (since `v4.3.0`)
+Whether or not to use `aqtinstall` to install Qt using its official online installer enabling the commercial versions for those owning a license.
+For this to work, you need to also set `aqtsource` to `git+https://github.com/Kidev/aqtinstall.git@install_qt_commercial`.
+The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.
+Example:
+```yml
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '5.15.3'
+        target: 'desktop'
+        arch: 'win64_msvc2019_64'
+        aqtsource: 'git+https://github.com/Kidev/aqtinstall.git@install_qt_commercial'
+        use-commercial: true
+        user: '****@gmail.com'
+        password: '****'
+```
+
+Default: `false`
+
+#### `user`
+If `use-commercial` is true, will use this username/email to authenticate with Qt servers
+
+#### `password`
+If `use-commercial` is true, will use this password to authenticate with Qt servers
+
 ### `install-deps`
 Whether or not to automatically install Qt dependencies on Linux through `apt`.
 

--- a/README.md
+++ b/README.md
@@ -32,20 +32,19 @@ This is the host platform of the Qt version you will be installing. It's unlikel
 
 For example, if you are building on Linux and targeting desktop, you would set host to `linux`. If you are building on Linux and targeting android, you would set host to `linux` also. The host platform is the platform that your application will build on, not its target platform.
 
-Possible values: `windows`, `mac`, `linux` or `all_os`_
-`all_os` is incompatible with `aqtinstall < 3.2.0`._
+Possible values: `windows`, `mac`, `linux` or `all_os`.  
+`all_os` is incompatible with `aqtinstall < 3.2.0`.  
 
-Defaults to the current platform it is being run on._
+Defaults to the current platform it is being run on.  
 
 
 ### `target`
 This is the target platform that you will be building for. You will want to set this if you are building for iOS or Android. Please note that iOS builds are supported only on macOS hosts and Win RT builds are only supported on Windows hosts.
 
-Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`_
-`wasm` is incompatible with `aqtinstall < 3.2.0`._
+Possible values: `desktop`, `android`, `ios`, `winrt` or `wasm`.  
+`wasm` is incompatible with `aqtinstall < 3.2.0`.  
 
-Default: `desktop`
-
+Default: `desktop`  
 
 
 ### `arch`
@@ -80,7 +79,7 @@ When possible, access your Qt directory through the `QT_ROOT_DIR` environment va
 Default: `$RUNNER_WORKSPACE` (this is one folder above the starting directory)
 
 ### `use-official` (since `v4.2.*`)
-Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions for those owning a license). Incompatible with `aqtinstall < 3.2.1`._
+Whether or not to use `aqtinstall` to install Qt using its official online installer (enabling the commercial versions for those owning a license). Incompatible with `aqtinstall < 3.2.1`.  
 The parameter `host` will then be ignored, as you can only install commercial Qt versions on the OS running the installer.  
 You should use secrets, and store the fields `email` and `pw` inside `QT_EMAIL` and `QT_PW` for example to match the example below.  
 
@@ -100,11 +99,11 @@ Example:
 Default: `false`
 
 #### `email`
-If `use-official` is true, will use this username/email to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`._
+If `use-official` is true, will use this username/email to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`.  
 You should use secrets, and store the value inside `QT_EMAIL` for example to match the example above.
 
 #### `pw`
-If `use-official` is true, will use this password to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`._
+If `use-official` is true, will use this password to authenticate with Qt servers. Incompatible with `aqtinstall < 3.2.1`.  
 You should use secrets, and store the value inside `QT_PW` for example to match the example above.
 
 ### `install-deps`

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Example:
         target: 'desktop'
         arch: 'win64_msvc2019_64'
         use-official: true
-        email: '****@gmail.com'
-        pw: '****'
+        email: ${{ secrets.QT_EMAIL }}
+        pw: ${{ secrets.QT_PW }}
 ```
 
 Default: `false`

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ Example:
         version: '5.15.3'
         target: 'desktop'
         arch: 'win64_msvc2019_64'
-        aqtsource: 'git+https://github.com/Kidev/aqtinstall.git@install_qt_commercial'
         use-official: true
         email: '****@gmail.com'
         pw: '****'

--- a/action.yml
+++ b/action.yml
@@ -55,7 +55,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.*
+    default: ==3.2.1
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.1"
+    default: "6.8.3"
   host:
     description: Host platform
   target:
@@ -55,7 +55,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.1
+    default: ">=3.2.1"
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.3"
+    default: "6.8.2"
   host:
     description: Host platform
   target:

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
     default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.20.*
+    default: ==0.22.*
   extra:
     description: Any extra arguments to append to the back
   source:
@@ -80,6 +80,15 @@ inputs:
     description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
   example-modules:
     description: Space-separated list of additional example modules to install.
+  use-commercial:
+    default: false
+    description: Whether or not to use aqtinstall to install the commercial version of Qt
+  user:
+    default: 'username'
+    description: Your Qt username
+  password:
+    default: 'password'
+    description: Your Qt password
 runs:
   using: "composite"
   steps:
@@ -87,7 +96,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '3.6.x - 3.12.x'
+      python-version: '3.6.x - 3.13.x'
 
   - name: Setup and run aqtinstall
     uses: ./action
@@ -119,3 +128,6 @@ runs:
       example-archives: ${{ inputs.example-archives }}
       example-modules: ${{ inputs.example-modules }}
       extra: ${{ inputs.extra }}
+      use-commercial: ${{ inputs.use-commercial }}
+      user: ${{ inputs.user }}
+      password: ${{ inputs.password }}

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "5.15.2"
+    default: "6.8.1"
   host:
     description: Host platform
   target:
@@ -55,7 +55,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.1.*
+    default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.20.*
@@ -87,7 +87,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '3.6.x - 3.11.x'
+      python-version: '3.6.x - 3.12.x'
 
   - name: Setup and run aqtinstall
     uses: ./action

--- a/action.yml
+++ b/action.yml
@@ -96,7 +96,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '3.9.x - 3.12.x'
+      python-version: '3.9.x - 3.13.x'
 
   - name: Setup and run aqtinstall
     uses: ./action

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.2"
+    default: "6.8.3"
   host:
     description: Host platform
   target:
@@ -55,7 +55,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ">=3.2.1"
+    default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action.yml
+++ b/action.yml
@@ -80,14 +80,14 @@ inputs:
     description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
   example-modules:
     description: Space-separated list of additional example modules to install.
-  use-commercial:
+  use-official:
     default: false
-    description: Whether or not to use aqtinstall to install the commercial version of Qt
-  user:
-    default: 'username'
-    description: Your Qt username
-  password:
-    default: 'password'
+    description: Whether to use aqtinstall to install Qt using the official installer, requires email & pw
+  email:
+    default: ''
+    description: Your Qt email
+  pw:
+    default: ''
     description: Your Qt password
 runs:
   using: "composite"
@@ -128,6 +128,6 @@ runs:
       example-archives: ${{ inputs.example-archives }}
       example-modules: ${{ inputs.example-modules }}
       extra: ${{ inputs.extra }}
-      use-commercial: ${{ inputs.use-commercial }}
-      user: ${{ inputs.user }}
-      password: ${{ inputs.password }}
+      use-official: ${{ inputs.use-official }}
+      email: ${{ inputs.email }}
+      pw: ${{ inputs.pw }}

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "5.15.2"
+    default: "6.8.1"
   host:
     description: Host platform
   target:
@@ -52,7 +52,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.1.*
+    default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.20.*

--- a/action/action.yml
+++ b/action/action.yml
@@ -52,7 +52,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.*
+    default: ==3.2.1
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action/action.yml
+++ b/action/action.yml
@@ -77,14 +77,14 @@ inputs:
     description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
   example-modules:
     description: Space-separated list of additional example modules to install.
-  use-commercial:
+  use-official:
     default: false
-    description: Whether or not to use aqtinstall to install the commercial version of Qt
-  user:
-    default: 'username'
-    description: Your Qt username
-  password:
-    default: 'password'
+    description: Whether to use aqtinstall to install Qt using the official installer, requires email & pw
+  email:
+    default: ''
+    description: Your Qt email
+  pw:
+    default: ''
     description: Your Qt password
 runs:
   using: node20

--- a/action/action.yml
+++ b/action/action.yml
@@ -55,7 +55,7 @@ inputs:
     default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.20.*
+    default: ==0.22.*
   extra:
     description: Any extra arguments to append to the back
   source:
@@ -77,6 +77,15 @@ inputs:
     description: Space-separated list of .7z example archives to install. Used to reduce download/image sizes.
   example-modules:
     description: Space-separated list of additional example modules to install.
+  use-commercial:
+    default: false
+    description: Whether or not to use aqtinstall to install the commercial version of Qt
+  user:
+    default: 'username'
+    description: Your Qt username
+  password:
+    default: 'password'
+    description: Your Qt password
 runs:
   using: node20
   main: lib/main.js

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.3"
+    default: "6.8.2"
   host:
     description: Host platform
   target:

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.1"
+    default: "6.8.3"
   host:
     description: Host platform
   target:
@@ -52,7 +52,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.1
+    default: ">=3.2.1"
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.2"
+    default: "6.8.3"
   host:
     description: Host platform
   target:
@@ -52,7 +52,7 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ">=3.2.1"
+    default: ==3.2.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
     default: ==0.22.*

--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/cache": "^3.2.4",
+        "@actions/cache": "^4.0.3",
         "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",
         "compare-versions": "^3.6.0",
@@ -29,11 +29,12 @@
       }
     },
     "node_modules/@actions/cache": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.2.4.tgz",
-      "integrity": "sha512-RuHnwfcDagtX+37s0ZWy7clbOfnZ7AlDJQ7k/9rzt2W4Gnwde3fa/qjSjVuz4vLcLIpc7fUob27CMrqiWZytYA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-4.0.3.tgz",
+      "integrity": "sha512-SvrqFtYJ7I48A/uXNkoJrnukx5weQv1fGquhs3+4nkByZThBH109KTIqj5x/cGV7JGNvb8dLPVywUOqX1fjiXg==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.10.0",
+        "@actions/core": "^1.11.1",
         "@actions/exec": "^1.0.1",
         "@actions/glob": "^0.1.0",
         "@actions/http-client": "^2.1.1",
@@ -41,25 +42,18 @@
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/storage-blob": "^12.13.0",
-        "semver": "^6.3.1",
-        "uuid": "^3.3.3"
+        "@protobuf-ts/plugin": "^2.9.4",
+        "semver": "^6.3.1"
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
+      "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      }
-    },
-    "node_modules/@actions/core/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "node_modules/@actions/exec": {
@@ -406,6 +400,83 @@
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ==",
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@protobuf-ts/plugin": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.6.tgz",
+      "integrity": "sha512-Wpv5rkXeu6E5Y4r0TjWE0bzRGddiTYl/RM+tLgVlS0r8CqOBqNAmlWv+s8ltf/F75rVrahUal0cpyhFwha9GRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/plugin-framework": "^2.9.6",
+        "@protobuf-ts/protoc": "^2.9.6",
+        "@protobuf-ts/runtime": "^2.9.6",
+        "@protobuf-ts/runtime-rpc": "^2.9.6",
+        "typescript": "^3.9"
+      },
+      "bin": {
+        "protoc-gen-dump": "bin/protoc-gen-dump",
+        "protoc-gen-ts": "bin/protoc-gen-ts"
+      }
+    },
+    "node_modules/@protobuf-ts/plugin-framework": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.6.tgz",
+      "integrity": "sha512-w7A1RXrDCiVzcaRE6YJP7FCARuAFe/Vc4SNQnHAi4CF0V6mEtyjAYEIC5BNYgIRaJEqB26zzsBQjIem3R02SCA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.9.6",
+        "typescript": "^3.9"
+      }
+    },
+    "node_modules/@protobuf-ts/plugin-framework/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@protobuf-ts/plugin/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/@protobuf-ts/protoc": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.6.tgz",
+      "integrity": "sha512-c0XvAPDIBAovH9HxV8gBv8gzOTreQIqibcusrB1+DxvFiSvy+2V1tjbUmG5gJEbjk3aAOaoj0a3+QuE+P28xUw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "protoc": "protoc.js"
+      }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.6.tgz",
+      "integrity": "sha512-C0CfpKx4n4LBbUrajOdRj2BTbd3qBoK0SiKWLq7RgCoU6xiN4wesBMFHUOBp3fFzKeZwgU8Q2KtzaqzIvPLRXg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.6.tgz",
+      "integrity": "sha512-0UeqDRzNxgsh08lY5eWzFJNfD3gZ8Xf+WG1HzbIAbVAigzigwjwsYNNhTeas5H3gco1U5owTzCg177aambKOOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.9.6"
       }
     },
     "node_modules/@types/glob": {
@@ -2106,15 +2177,6 @@
         "punycode": "^2.1.0"
       }
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -2205,11 +2267,11 @@
   },
   "dependencies": {
     "@actions/cache": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-3.2.4.tgz",
-      "integrity": "sha512-RuHnwfcDagtX+37s0ZWy7clbOfnZ7AlDJQ7k/9rzt2W4Gnwde3fa/qjSjVuz4vLcLIpc7fUob27CMrqiWZytYA==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@actions/cache/-/cache-4.0.3.tgz",
+      "integrity": "sha512-SvrqFtYJ7I48A/uXNkoJrnukx5weQv1fGquhs3+4nkByZThBH109KTIqj5x/cGV7JGNvb8dLPVywUOqX1fjiXg==",
       "requires": {
-        "@actions/core": "^1.10.0",
+        "@actions/core": "^1.11.1",
         "@actions/exec": "^1.0.1",
         "@actions/glob": "^0.1.0",
         "@actions/http-client": "^2.1.1",
@@ -2217,24 +2279,17 @@
         "@azure/abort-controller": "^1.1.0",
         "@azure/ms-rest-js": "^2.6.0",
         "@azure/storage-blob": "^12.13.0",
-        "semver": "^6.3.1",
-        "uuid": "^3.3.3"
+        "@protobuf-ts/plugin": "^2.9.4",
+        "semver": "^6.3.1"
       }
     },
     "@actions/core": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.1.tgz",
-      "integrity": "sha512-3lBR9EDAY+iYIpTnTIXmWcNbX3T2kCkAEQGIQx4NVQ0575nk2k3GRZDTPQG+vVtS2izSLmINlxXf0uLtnrTP+g==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==",
       "requires": {
-        "@actions/http-client": "^2.0.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
-        }
+        "@actions/exec": "^1.1.1",
+        "@actions/http-client": "^2.0.1"
       }
     },
     "@actions/exec": {
@@ -2541,6 +2596,59 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.1.0.tgz",
       "integrity": "sha512-hf+3bwuBwtXsugA2ULBc95qxrOqP2pOekLz34BJhcAKawt94vfeNyUKpYc0lZQ/3sCP6LqRa7UAdHA7i5UODzQ=="
+    },
+    "@protobuf-ts/plugin": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin/-/plugin-2.9.6.tgz",
+      "integrity": "sha512-Wpv5rkXeu6E5Y4r0TjWE0bzRGddiTYl/RM+tLgVlS0r8CqOBqNAmlWv+s8ltf/F75rVrahUal0cpyhFwha9GRA==",
+      "requires": {
+        "@protobuf-ts/plugin-framework": "^2.9.6",
+        "@protobuf-ts/protoc": "^2.9.6",
+        "@protobuf-ts/runtime": "^2.9.6",
+        "@protobuf-ts/runtime-rpc": "^2.9.6",
+        "typescript": "^3.9"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+        }
+      }
+    },
+    "@protobuf-ts/plugin-framework": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/plugin-framework/-/plugin-framework-2.9.6.tgz",
+      "integrity": "sha512-w7A1RXrDCiVzcaRE6YJP7FCARuAFe/Vc4SNQnHAi4CF0V6mEtyjAYEIC5BNYgIRaJEqB26zzsBQjIem3R02SCA==",
+      "requires": {
+        "@protobuf-ts/runtime": "^2.9.6",
+        "typescript": "^3.9"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.9.10",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+          "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q=="
+        }
+      }
+    },
+    "@protobuf-ts/protoc": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/protoc/-/protoc-2.9.6.tgz",
+      "integrity": "sha512-c0XvAPDIBAovH9HxV8gBv8gzOTreQIqibcusrB1+DxvFiSvy+2V1tjbUmG5gJEbjk3aAOaoj0a3+QuE+P28xUw=="
+    },
+    "@protobuf-ts/runtime": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.9.6.tgz",
+      "integrity": "sha512-C0CfpKx4n4LBbUrajOdRj2BTbd3qBoK0SiKWLq7RgCoU6xiN4wesBMFHUOBp3fFzKeZwgU8Q2KtzaqzIvPLRXg=="
+    },
+    "@protobuf-ts/runtime-rpc": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.9.6.tgz",
+      "integrity": "sha512-0UeqDRzNxgsh08lY5eWzFJNfD3gZ8Xf+WG1HzbIAbVAigzigwjwsYNNhTeas5H3gco1U5owTzCg177aambKOOw==",
+      "requires": {
+        "@protobuf-ts/runtime": "^2.9.6"
+      }
     },
     "@types/glob": {
       "version": "7.2.0",
@@ -3731,11 +3839,6 @@
       "requires": {
         "punycode": "^2.1.0"
       }
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -868,10 +868,11 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1590,12 +1591,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -2857,9 +2859,9 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "requires": {
         "path-key": "^3.1.0",
@@ -3396,12 +3398,12 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       }
     },

--- a/action/package.json
+++ b/action/package.json
@@ -16,7 +16,7 @@
   "author": "jurplel",
   "license": "MIT",
   "dependencies": {
-    "@actions/cache": "^3.2.4",
+    "@actions/cache": "^4.0.3",
     "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "compare-versions": "^3.6.0",

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -104,8 +104,8 @@ const isAutodesktopSupported = async (): Promise<boolean> => {
 };
 
 class Inputs {
-  readonly host: "windows" | "mac" | "linux";
-  readonly target: "desktop" | "android" | "ios";
+  readonly host: "windows" | "mac" | "linux" | "all_os";
+  readonly target: "desktop" | "android" | "ios" | "wasm";
   readonly version: string;
   readonly arch: string;
   readonly dir: string;
@@ -156,19 +156,19 @@ class Inputs {
       }
     } else {
       // Make sure host is one of the allowed values
-      if (host === "windows" || host === "mac" || host === "linux") {
+      if (host === "windows" || host === "mac" || host === "linux" || host === "all_os") {
         this.host = host;
       } else {
-        throw TypeError(`host: "${host}" is not one of "windows" | "mac" | "linux"`);
+        throw TypeError(`host: "${host}" is not one of "windows" | "mac" | "linux" | "all_os"`);
       }
     }
 
     const target = core.getInput("target");
     // Make sure target is one of the allowed values
-    if (target === "desktop" || target === "android" || target === "ios") {
+    if (target === "desktop" || target === "android" || target === "ios" || target === "wasm") {
       this.target = target;
     } else {
-      throw TypeError(`target: "${target}" is not one of "desktop" | "android" | "ios"`);
+      throw TypeError(`target: "${target}" is not one of "desktop" | "android" | "ios" | "wasm"`);
     }
 
     // An attempt to sanitize non-straightforward version number input
@@ -185,6 +185,12 @@ class Inputs {
           this.arch = "android";
         } else {
           this.arch = "android_armv7";
+        }
+      } else if (this.target === "wasm") {
+        if (compareVersions(this.version, ">=", "6.0.0")) {
+          this.arch = "wasm_singlethread";
+        } else {
+          this.arch = "wasm_32";
         }
       } else if (this.host === "windows") {
         if (compareVersions(this.version, ">=", "6.8.0")) {

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -186,12 +186,6 @@ class Inputs {
         } else {
           this.arch = "android_armv7";
         }
-      } else if (this.target === "wasm") {
-        if (compareVersions(this.version, ">=", "6.0.0")) {
-          this.arch = "wasm_singlethread";
-        } else {
-          this.arch = "wasm_32";
-        }
       } else if (this.host === "windows") {
         if (compareVersions(this.version, ">=", "6.8.0")) {
           this.arch = "win64_msvc2022_64";

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -100,58 +100,6 @@ const locateQtArchDir = (installDir: string): [string, boolean] => {
   }
 };
 
-const locateQtWasmHostArchDir = (
-  installDir: string,
-  hostType: "windows" | "mac" | "linux" | "all_os",
-  target: "desktop" | "android" | "ios" | "wasm",
-  version: string
-): [string, boolean] => {
-  // For WASM in all_os mode, use the host builder directory
-  if (hostType === "all_os" && target === "wasm") {
-    const versionDir = path.join(installDir, version);
-
-    switch (process.platform) {
-      case "win32": {
-        // Find mingw directories
-        const mingwPattern = /^win\d+_mingw\d+$/;
-        const mingwArches = glob
-          .sync(`${versionDir}/*/`)
-          .map((dir) => path.basename(dir))
-          .filter((dir) => mingwPattern.test(dir))
-          .sort((a, b) => {
-            const [aBits, aVer] = a
-              .match(/win(\d+)_mingw(\d+)/)
-              ?.slice(1)
-              .map(Number) ?? [0, 0];
-            const [bBits, bVer] = b
-              .match(/win(\d+)_mingw(\d+)/)
-              ?.slice(1)
-              .map(Number) ?? [0, 0];
-            if (aBits !== bBits) return bBits - aBits;
-            return bVer - aVer;
-          });
-
-        if (!mingwArches.length) {
-          throw Error(`Failed to locate a MinGW directory for WASM host in ${versionDir}`);
-        }
-        return [path.join(versionDir, mingwArches[0]), false];
-      }
-      case "darwin":
-        return [path.join(versionDir, "clang_64"), false];
-      default:
-        return [
-          path.join(
-            versionDir,
-            "gcc_64"
-          ),
-          false,
-        ];
-    }
-  }
-
-  return locateQtArchDir(installDir);
-};
-
 const isAutodesktopSupported = async (): Promise<boolean> => {
   const rawOutput = await getPythonOutput("aqt", ["version"]);
   const match = rawOutput.match(/aqtinstall\(aqt\)\s+v(\d+\.\d+\.\d+)/);
@@ -534,12 +482,7 @@ const run = async (): Promise<void> => {
   }
   // Set environment variables/outputs for binaries
   if (inputs.isInstallQtBinaries) {
-    const [qtPath, requiresParallelDesktop] = locateQtWasmHostArchDir(
-      inputs.dir,
-      inputs.host,
-      inputs.target,
-      inputs.version
-    );
+    const [qtPath, requiresParallelDesktop] = locateQtArchDir(inputs.dir);
     // Set outputs
     core.setOutput("qtPath", qtPath);
 

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -142,7 +142,7 @@ const locateQtWasmHostArchDir = (
         return [
           path.join(
             versionDir,
-            compareVersions(version, ">=", "6.7.0") ? "linux_gcc_64" : "gcc_64"
+            "gcc_64"
           ),
           false,
         ];

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -105,7 +105,7 @@ const locateQtWasmHostArchDir = (
   hostType: "windows" | "mac" | "linux" | "all_os",
   target: "desktop" | "android" | "ios" | "wasm",
   version: string
-): string => {
+): [string, boolean] => {
   // For WASM in all_os mode, use the host builder directory
   if (hostType === "all_os" && target === "wasm") {
     const versionDir = path.join(installDir, version);
@@ -134,15 +134,18 @@ const locateQtWasmHostArchDir = (
         if (!mingwArches.length) {
           throw Error(`Failed to locate a MinGW directory for WASM host in ${versionDir}`);
         }
-        return path.join(versionDir, mingwArches[0]);
+        return [path.join(versionDir, mingwArches[0]), false];
       }
       case "darwin":
-        return path.join(versionDir, "clang_64");
+        return [path.join(versionDir, "clang_64"), false];
       default:
-        return path.join(
-          versionDir,
-          compareVersions(version, ">=", "6.7.0") ? "linux_gcc_64" : "gcc_64"
-        );
+        return [
+          path.join(
+            versionDir,
+            compareVersions(version, ">=", "6.7.0") ? "linux_gcc_64" : "gcc_64"
+          ),
+          false,
+        ];
     }
   }
 
@@ -531,7 +534,12 @@ const run = async (): Promise<void> => {
   }
   // Set environment variables/outputs for binaries
   if (inputs.isInstallQtBinaries) {
-    const [qtPath, requiresParallelDesktop] = locateQtWasmHostArchDir(inputs.dir, inputs.host, inputs.target, inputs.version);
+    const [qtPath, requiresParallelDesktop] = locateQtWasmHostArchDir(
+      inputs.dir,
+      inputs.host,
+      inputs.target,
+      inputs.version
+    );
     // Set outputs
     core.setOutput("qtPath", qtPath);
 

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -191,9 +191,9 @@ class Inputs {
   readonly aqtVersion: string;
   readonly py7zrVersion: string;
 
-  readonly useCommercial: boolean;
-  readonly user: string;
-  readonly password: string;
+  readonly useOfficial: boolean;
+  readonly email: string;
+  readonly pw: string;
 
   constructor() {
     const host = core.getInput("host");
@@ -301,9 +301,9 @@ class Inputs {
 
     this.py7zrVersion = core.getInput("py7zrversion");
 
-    this.useCommercial = Inputs.getBoolInput("use-commercial");
-    this.user = core.getInput("user");
-    this.password = core.getInput("password");
+    this.useOfficial = Inputs.getBoolInput("use-official");
+    this.email = core.getInput("email");
+    this.pw = core.getInput("pw");
 
     this.src = Inputs.getBoolInput("source");
     this.srcArchives = Inputs.getStringArrayInput("src-archives");
@@ -330,7 +330,7 @@ class Inputs {
         this.py7zrVersion,
         this.aqtSource,
         this.aqtVersion,
-        this.useCommercial ? "commercial" : "",
+        this.useOfficial ? "official" : "",
       ],
       this.modules,
       this.archives,
@@ -450,15 +450,15 @@ const run = async (): Promise<void> => {
 
     // Install Qt
     if (inputs.isInstallQtBinaries) {
-      if (inputs.useCommercial && inputs.user && inputs.password) {
+      if (inputs.useOfficial && inputs.email && inputs.pw) {
         const qtArgs = [
-          "install-qt-commercial",
+          "install-qt-official",
           inputs.target,
           ...(inputs.arch ? [inputs.arch] : []),
           inputs.version,
           ...["--outputdir", inputs.dir],
-          ...["--user", inputs.user],
-          ...["--password", inputs.password],
+          ...["--email", inputs.email],
+          ...["--pw", inputs.pw],
           ...flaggedList("--modules", inputs.modules),
           ...inputs.extra,
         ];


### PR DESCRIPTION
## This PR includes
- Updates to parameters and logic to handle the latest `aqtinstall` versions, making the action once again able to install any version of Qt, WASM and extensions included (`aqtinstall` >=3.2.0)  
- Add full support for installing Qt commercial versions provided you own a Qt account (paid or not). The account is required even if you only download open-source versions (`aqtinstall` >=3.2.2)  
- Updated outdated defaults, and used Qt 6.8.3 as LTS  
- Updated @action/cache to v4 to match Github's update

### Context
Since Qt 6.7+, the Qt team decided to make WASM a part of `all_os` as host, with target `wasm`. This is sensible as the WASM version of Qt cannot work on its own and needs a host. To install Qt WASM for the latest versions, the `host` and `target` values must be edited. See examples.  
This change is required by the latest versions of `aqtinstall` (>=3.2.0)

## Examples:  

> [!TIP]
> Click [run] to see a successful Github Action run using each example
> Click [workflow] to see the corresponding workflow

### Latest Qt WASM [[run](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14232248777/job/39885109392#step:6:1)] [[workflow](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14232248777/workflow)]
```yaml
- name: Install Qt for host and WASM
  uses: jurplel/install-qt-action@v4
  with:
    version: '6.8.2'
    host: 'all_os'
    target: 'wasm'
    arch: 'wasm_singlethread'
    modules: 'qtquick3d'
```
Notice `host` and `target`. Since `--autodesktop` is always implied, this will download WASM for the current OS (so this will download `linux_gcc_64` and `wasm_singlethread` if ran on `linux`).  

### Qt commercial [[run](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14366206584/job/40279631228#step:6:1)] [[workflow](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14366206584/workflow)]: 
```yaml
- name: Install Qt commercial
  uses: jurplel/install-qt-action@v4
  with:
    version: '6.8.2'
    target: 'desktop'
    arch: 'linux_gcc_64'
    use-official: true
    email: ${{ secrets.QT_USERNAME }}
    pw: ${{ secrets.QT_PASSWORD }}
    modules: 'qtquick3d'
```
Notice the absence of `host`: the official installer only installs using the current OS as `host`. If provided, it will be ignored. You should use secrets for the login information. This will download `linux_gcc_64` for `linux` using the official installer. If you own a paid Qt license, you can use a commercial only version in the `version` field, and it will work.   

### Qt commercial WASM [[run](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14232259167/job/39885140618#step:6:1)] [[workflow](https://github.com/Kidev/QtQuick3D-Tools/actions/runs/14232259167/workflow)] 
```yaml
- name: Install Qt commercial
  uses: jurplel/install-qt-action@v4
  with:
    version: '6.8.2'
    target: 'desktop'
    arch: 'linux_gcc_64'
    use-official: true
    email: ${{ secrets.QT_USERNAME }}
    pw: ${{ secrets.QT_PASSWORD }}
    modules: 'wasm_singlethread qtquick3d'
```
Same as the previous one, `host` is implied. For the official installer however, there is no `--autodesktop`. Instead, the `modules` field get a widened meaning, and includes all [Qt packages](https://doc.qt.io/qt-6/get-and-install-qt-cli.html#component-names-for-installation). So this example will install Qt for `linux` (implied to be the `host`), for the WASM host architecture `linux_gcc_64`, and will download the `wasm_singlethread` package (considered the target) along with `qtquick3d` for both.  

