### PR TITLE
Support ARM64 hosts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,6 +96,11 @@ jobs:
             qt:
               tools-only-build: true
               add-tools-to-path: false
+          - os: ubuntu-24.04-arm
+            qt:
+              version: "6.8.1"
+              requested: "6.8.1"
+              modules: qtwebengine qtpositioning qtwebchannel
 
 
     steps:
@@ -123,7 +128,7 @@ jobs:
           dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
-          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          tools: tools_ifw tools_qtcreator_gui,qt.tools.qtcreator_gui
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Install Qt with options and specified aqtversion
@@ -134,7 +139,7 @@ jobs:
           dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
-          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator
+          tools: tools_ifw tools_qtcreator_gui,qt.tools.qtcreator_gui
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Test QT_ROOT_DIR
@@ -228,7 +233,7 @@ jobs:
         with:
           dir: ${{ matrix.dir }}
           tools-only: true
-          tools: tools_ifw tools_qtcreator,qt.tools.qtcreator tools_cmake tools_ninja tools_conan
+          tools: tools_ifw tools_qtcreator_gui,qt.tools.qtcreator_gui tools_cmake tools_ninja tools_conan
           add-tools-to-path: ${{ matrix.qt.add-tools-to-path }}
           cache: ${{ matrix.cache == 'cached' }}
 
@@ -240,7 +245,7 @@ jobs:
           set -x
 
           # tools_ifw: use `archivegen` to test that Tools/QtInstallerFramework/4.7/bin is added to path
-          # tools_qtcreator: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is added to path
+          # tools_qtcreator_gui: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is added to path
           # tools_cmake: test that Tools/CMake/bin or Tools/CMake/CMake.app/Contents/bin is added to path
           # tools_ninja: test that Tools/Ninja is added to path
           # tools_conan: test that Tools/Conan is added to path
@@ -270,7 +275,7 @@ jobs:
           [[ -e "../Qt/Tools/Conan/conan" ]]
 
           # tools_ifw: use `archivegen` to test that Tools/QtInstallerFramework/4.7/bin is not added to path
-          # tools_qtcreator: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is not added to path
+          # tools_qtcreator_gui: use `qbs` to test that Tools/QtCreator/bin or "Qt Creator.app/Contents/MacOS/" is not added to path
           # tools_cmake: test that Tools/CMake/bin or Tools/CMake/CMake.app/Contents/bin is not added to path
           # tools_ninja: test that Tools/Ninja is not added to path
           # tools_conan: test that Tools/Conan is not added to path

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,12 @@ jobs:
               version: "6.8.1"
               requested: "6.8.1"
               modules: qtwebengine qtpositioning qtwebchannel
+          - os: windows-11-arm
+            skip-test-project: true
+            qt:
+              version: "6.8.1"
+              requested: "6.8.1"
+              modules: qtpositioning qtwebchannel
 
 
     steps:
@@ -128,7 +134,7 @@ jobs:
           dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
-          tools: tools_ifw tools_qtcreator_gui,qt.tools.qtcreator_gui
+          tools: tools_qtcreator_gui,qt.tools.qtcreator_gui
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Install Qt with options and specified aqtversion
@@ -139,7 +145,7 @@ jobs:
           dir: ${{ matrix.dir }}
           modules: ${{ matrix.qt.modules }}
           version: ${{ matrix.qt.requested }}
-          tools: tools_ifw tools_qtcreator_gui,qt.tools.qtcreator_gui
+          tools: tools_qtcreator_gui,qt.tools.qtcreator_gui
           cache: ${{ matrix.cache == 'cached' }}
 
       - name: Test QT_ROOT_DIR
@@ -162,7 +168,7 @@ jobs:
           }
 
       - name: Configure test project on windows
-        if: ${{ matrix.qt.version && startsWith(matrix.os, 'windows') }}
+        if: ${{ matrix.qt.version && startsWith(matrix.os, 'windows') && !matrix.skip-test-project }}
         env:
           QT_VERSION: ${{ matrix.qt.version }}
         run: |
@@ -174,7 +180,7 @@ jobs:
         shell: cmd
 
       - name: Configure test project on unix
-        if: ${{ matrix.qt.version && !startsWith(matrix.os, 'windows') }}
+        if: ${{ matrix.qt.version && !startsWith(matrix.os, 'windows') && !matrix.skip-test-project }}
         env:
           QT_VERSION: ${{ matrix.qt.version }}
         run: |

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This is the host platform of the Qt version you will be installing. It's unlikel
 
 For example, if you are building on Linux and targeting desktop, you would set host to `linux`. If you are building on Linux and targeting android, you would set host to `linux` also. The host platform is the platform that your application will build on, not its target platform.
 
-Possible values: `windows`, `mac`, or `linux`
+Possible values: `windows`, `windows_arm64`, `mac`, `linux` or `linux_arm64`
 
 Defaults to the current platform it is being run on.
 
@@ -63,6 +63,8 @@ Windows w/ Qt >= 5.9 && Qt < 5.15: `win64_msvc2017_64`
 Windows w/ Qt >= 5.15 && Qt < 6.8: `win64_msvc2019_64`
 
 Windows w/ Qt >= 6.8: `win64_msvc2022_64`
+
+Windows (ARM64) w/ Qt >= 6.8: `win64_msvc2022_arm64`
 
 Android: `android_armv7`
 

--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,8 @@ runs:
     uses: actions/setup-python@v5
     with:
       python-version: '3.9.x - 3.12.x'
+      # Workaround for https://codeberg.org/miurahr/pyppmd/issues/128
+      architecture: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && 'x64' || '' }}
 
   - name: Setup and run aqtinstall
     uses: ./action

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -71,21 +71,23 @@ const flaggedList = (flag: string, listArgs: readonly string[]): string[] => {
   return listArgs.length ? [flag, ...listArgs] : [];
 };
 
-const locateQtArchDir = (installDir: string): [string, boolean] => {
+const locateQtArchDir = (installDir: string, host: string): [string, boolean] => {
   // For 6.4.2/gcc, qmake is at 'installDir/6.4.2/gcc_64/bin/qmake'.
   // This makes a list of all the viable arch directories that contain a qmake file.
   const qtArchDirs = glob
     .sync(`${installDir}/[0-9]*/*/bin/qmake*`)
     .map((s) => path.resolve(s, "..", ".."));
 
-  // For Qt6 mobile and wasm installations, and Qt6 Windows on ARM installations,
+  // For Qt6 mobile and wasm installations, and Qt6 Windows on ARM cross-compiled installations,
   // a standard desktop Qt installation must exist alongside the requested architecture.
   // In these cases, we must select the first item that ends with 'android*', 'ios', 'wasm*' or 'msvc*_arm64'.
   const requiresParallelDesktop = qtArchDirs.filter((archPath) => {
     const archDir = path.basename(archPath);
     const versionDir = path.basename(path.join(archPath, ".."));
     return (
-      versionDir.match(/^6\.\d+\.\d+$/) && archDir.match(/^(android.*|ios|wasm.*|msvc.*_arm64)$/)
+      versionDir.match(/^6\.\d+\.\d+$/) &&
+      (archDir.match(/^(android.*|ios|wasm.*)$/) ||
+        (archDir.match(/^msvc.*_arm64$/) && host !== "windows_arm64"))
     );
   });
   if (requiresParallelDesktop.length) {
@@ -106,7 +108,7 @@ const isAutodesktopSupported = async (): Promise<boolean> => {
 };
 
 class Inputs {
-  readonly host: "windows" | "mac" | "linux";
+  readonly host: "windows" | "windows_arm64" | "mac" | "linux" | "linux_arm64";
   readonly target: "desktop" | "android" | "ios";
   readonly version: string;
   readonly arch: string;
@@ -144,7 +146,7 @@ class Inputs {
     if (!host) {
       switch (process.platform) {
         case "win32": {
-          this.host = "windows";
+          this.host = process.arch === "arm64" ? "windows_arm64" : "windows";
           break;
         }
         case "darwin": {
@@ -152,16 +154,24 @@ class Inputs {
           break;
         }
         default: {
-          this.host = "linux";
+          this.host = process.arch === "arm64" ? "linux_arm64" : "linux";
           break;
         }
       }
     } else {
       // Make sure host is one of the allowed values
-      if (host === "windows" || host === "mac" || host === "linux") {
+      if (
+        host === "windows" ||
+        host === "windows_arm64" ||
+        host === "mac" ||
+        host === "linux" ||
+        host === "linux_arm64"
+      ) {
         this.host = host;
       } else {
-        throw TypeError(`host: "${host}" is not one of "windows" | "mac" | "linux"`);
+        throw TypeError(
+          `host: "${host}" is not one of "windows" | "windows_arm64" | "mac" | "linux" | "linux_arm64"`
+        );
       }
     }
 
@@ -200,6 +210,8 @@ class Inputs {
         } else {
           this.arch = "win64_msvc2017_64";
         }
+      } else if (this.host === "windows_arm64") {
+        this.arch = "win64_msvc2022_arm64";
       }
     }
 
@@ -457,7 +469,7 @@ const run = async (): Promise<void> => {
   }
   // Set environment variables/outputs for binaries
   if (inputs.isInstallQtBinaries) {
-    const [qtPath, requiresParallelDesktop] = locateQtArchDir(inputs.dir);
+    const [qtPath, requiresParallelDesktop] = locateQtArchDir(inputs.dir, inputs.host);
     // Set outputs
     core.setOutput("qtPath", qtPath);
 


### PR DESCRIPTION
Fixes #248. The Linux part is working fine, I already have my `kimageformats-binaries` and `qView` forks using it and building a working aarch64 AppImage. I haven't tested the Windows part since the ARM64 Windows runners aren't public yet.

If anyone needs to use this before the pull request is merged and released, my [install-qt-action fork](https://github.com/jdpurcell/install-qt-action) makes it possible.