### PR TITLE
Fix error on windows-2019 runners

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -87,7 +87,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '>=3.9.x'
+      python-version: '3.9.x - 3.12.x'
 
   - name: Setup and run aqtinstall
     uses: ./action


### PR DESCRIPTION
[This commit](https://github.com/jurplel/install-qt-action/commit/e892482d6820b3e964f0b65c74de60f8014931d5) introduced failures on the `windows-2019` runners. Unless someone can figure out why it's failing with Python 3.13.x, I would propose limiting Python to 3.12.x for now.

If GitHub follows their usual policy, `windows-2019` might go away soon anyway (mid-2025?) after the `windows-2025` runner is out of beta, so this version restriction could be reverted after that.