### PR TITLE
Fix bdist_wheel error

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -373,7 +373,7 @@ const run = async (): Promise<void> => {
   // Install Qt and tools if not cached
   if (!internalCacheHit) {
     // Install dependencies via pip
-    await execPython("pip install", ["setuptools", "wheel", `"py7zr${inputs.py7zrVersion}"`]);
+    await execPython("pip install", ["setuptools>=70.1.0", `"py7zr${inputs.py7zrVersion}"`]);
 
     // Install aqtinstall separately: allows aqtinstall to override py7zr if required
     if (inputs.aqtSource.length > 0) {


### PR DESCRIPTION
Fixes #281. `setuptools` version chosen per recommendation [here](https://github.com/pypa/wheel/issues/660#issuecomment-2775668964), and this eliminates the need to install `wheel`.