### PR TITLE
Update aqt/py7zr versions and update Python versions accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ By default this is unset and ignored.
 
 Version of [aqtinstall](https://github.com/miurahr/aqtinstall) to use, given in the format used by pip, for example: `==0.7.1`, `>=0.7.1`, `==0.7.*`. This is intended to be used to troubleshoot any bugs that might be caused or fixed by certain versions of aqtinstall.
 
-Default: `==3.2.*`
+Default: `==3.3.*`
 
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
 
-Default: `==0.22.*`
+Default: `==1.0.*`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.
@@ -312,8 +312,8 @@ Example value: `--external 7z`
         tools: 'tools_ifw tools_qtcreator,qt.tools.qtcreator'
         set-env: 'true'
         tools-only: 'false'
-        aqtversion: '==3.2.*'
-        py7zrversion: '==0.22.*'
+        aqtversion: '==3.3.*'
+        py7zrversion: '==1.0.*'
         extra: '--external 7z'
         use-official: false
         email: ${{ secrets.QT_EMAIL }}

--- a/action.yml
+++ b/action.yml
@@ -55,10 +55,10 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.*
+    default: ==3.3.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.22.*
+    default: ==1.0.*
   extra:
     description: Any extra arguments to append to the back
   source:
@@ -96,9 +96,7 @@ runs:
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@v5
     with:
-      python-version: '3.10.x - 3.12.x'
-      # Workaround for https://codeberg.org/miurahr/pyppmd/issues/128
-      architecture: ${{ runner.os == 'Windows' && runner.arch == 'ARM64' && 'x64' || '' }}
+      python-version: '3.9.x - 3.13.x'
 
   - name: Setup and run aqtinstall
     uses: ./action

--- a/action/action.yml
+++ b/action/action.yml
@@ -52,10 +52,10 @@ inputs:
     description: Location to source aqtinstall from in case of issues
   aqtversion:
     description: Version of aqtinstall to use in case of issues
-    default: ==3.2.*
+    default: ==3.3.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==0.22.*
+    default: ==1.0.*
   extra:
     description: Any extra arguments to append to the back
   source:


### PR DESCRIPTION
aqtinstall 3.3.0 was released a few days ago which fixes the incompatibility with Python 3.9. It also uses a newer pyppmd release which fixes some build issues with MSVC2019 as well as Windows ARM64, plus it even has wheels for 3.13 now (i.e. don't need to build from source anyway).

Fixes #279 and #287.