### PR TITLE
Bump Node.js to v24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
   steps:
   - name: Setup Python
     if: ${{ inputs.setup-python  == 'true' }}
-    uses: actions/setup-python@v5
+    uses: actions/setup-python@v6
     with:
       python-version: '>=3.9.0 <=3.13.3'
 

--- a/action/action.yml
+++ b/action/action.yml
@@ -87,5 +87,5 @@ inputs:
     default: ''
     description: Your Qt password
 runs:
-  using: node20
+  using: node24
   main: lib/main.js


### PR DESCRIPTION
As [Node.js 20 is now deprecated on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), bump Node.js to v24.

This needs to be done in two places:

1. `./action/action.yml` for this action itself; and
2. `./action.yml`'s `actions/setup-python` step - bumped from v5 to v6 ([v6.0.0 upgraded to Node.js 24](https://github.com/actions/setup-python/releases/tag/v6.0.0)).

Should resolve https://github.com/jurplel/install-qt-action/issues/300 and https://github.com/jurplel/install-qt-action/issues/306.