### PR TITLE
Support CMake 4

### DIFF
--- a/tests/TestWithModules/CMakeLists.txt
+++ b/tests/TestWithModules/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1.0...4.2.3 FATAL_ERROR)
 
 project(whatspoppin VERSION 1.0.0 LANGUAGES CXX)
 


### PR DESCRIPTION
All of GitHub's macOS runners are now using CMake 4 (v4.2.3):

* [macos-14-Readme.md#L81](https://github.com/actions/runner-images/blob/563ad669b646f6f3d68e17b9d83d4028806becb6/images/macos/macos-14-Readme.md?plain=1#L81)
* [macos-15-Readme.md#L79](https://github.com/actions/runner-images/blob/563ad669b646f6f3d68e17b9d83d4028806becb6/images/macos/macos-15-Readme.md?plain=1#L79)
* [macos-26-Readme.md#L79](https://github.com/actions/runner-images/blob/563ad669b646f6f3d68e17b9d83d4028806becb6/images/macos/macos-26-Readme.md?plain=1#L79)

Per the [CMake v4.0.0 announcement](https://www.kitware.com/cmake-4-0-0-available-for-download/): 

> Compatibility with versions of CMake older than 3.5 has been
removed. Calls to “cmake_minimum_required()” or “cmake_policy()”
that set the policy version to an older value now issue an error.

Consequently, `macos-*` test workflows are failing.

To resolve this, we update [`cmake_minimum_required`](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html) to specify a `<policy_max>` of 4.2.3 to indicate that _at least_ that version has been tested (`<policy_max>` does not enforce a limit), ie:

> **Note** `...<policy_max>` does not signify that later CMake versions are forbidden. It merely specifies the highest CMake version for which the project or module has been actively updated and maintained[^1]

Also included the `FATAL_ERROR` argument, as is specifically recommended by CMake:

> The `FATAL_ERROR` option is accepted but ignored by CMake 2.6 and higher. It should be specified so CMake versions 2.4 and lower fail with an error instead of just a warning.[^2]


[^1]: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#index-0-variable:CMAKE_POLICY_DEFAULT_CMP%3CNNNN%3E
[^2]: https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#index-0-variable:CMAKE_MINIMUM_REQUIRED_VERSION