### PR TITLE
CI: Remove `macos-14` runner image

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -13,7 +13,6 @@ jobs:
           - ubuntu-24.04
           - windows-2022
           - windows-2025
-          - macos-14
           - macos-15
           - macos-15-intel
           - macos-26

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,6 @@ jobs:
           - ubuntu-24.04
           - windows-2022
           - windows-2025
-          - macos-14
           - macos-15
           - macos-15-intel
           - macos-26


### PR DESCRIPTION
It's support is scheduled to be sunset.

* https://github.com/actions/runner-images/issues/13518