### PR TITLE
CI: Remove macOS 15 based runner images

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -13,8 +13,6 @@ jobs:
           - ubuntu-24.04
           - windows-2022
           - windows-2025
-          - macos-15
-          - macos-15-intel
           - macos-26
           - macos-26-intel
         qt:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,8 +33,6 @@ jobs:
           - ubuntu-24.04
           - windows-2022
           - windows-2025
-          - macos-15
-          - macos-15-intel
           - macos-26
           - macos-26-intel
         aqtversion:


### PR DESCRIPTION
* Removed `macos15` runner image - ARM64 (Apple Silicon)
* Removed `macos-15-intel` runner image - x86_64 (Intel)