### PR TITLE
CI: Make runs in forked repositories manual

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -1,9 +1,31 @@
 name: CI-android
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      # The following input and its usage are based on the "rclone/rclone" project.
+      # https://github.com/rclone/rclone/blob/c1f5df209024c79028c98134b703b31d599befac/.github/workflows/build.yml#L24
+      # Copyright (C) 2012 by Nick Craig-Wood http://www.craig-wood.com/nick/. Licensed under MIT.
+      manual:
+        description: Manual run (bypass default conditions)
+        required: true
+        type: choice
+        default: 'TRUE'
+        options:
+          - 'TRUE'
 
 jobs:
   test:
+    if: >-
+      inputs.manual || (
+        github.repository == 'jurplel/install-qt-action' && (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name ||
+          github.event.pull_request.user.login == 'dependabot[bot]'
+        )
+      )
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,31 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      # The following input and its usage are based on the "rclone/rclone" project.
+      # https://github.com/rclone/rclone/blob/c1f5df209024c79028c98134b703b31d599befac/.github/workflows/build.yml#L24
+      # Copyright (C) 2012 by Nick Craig-Wood http://www.craig-wood.com/nick/. Licensed under MIT.
+      manual:
+        description: Manual run (bypass default conditions)
+        required: true
+        type: choice
+        default: 'TRUE'
+        options:
+          - 'TRUE'
 
 jobs:
   lint:
+    if: >-
+      inputs.manual || (
+        github.repository == 'jurplel/install-qt-action' && (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name ||
+          github.event.pull_request.user.login == 'dependabot[bot]'
+        )
+      )
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,6 +46,14 @@ jobs:
           npm run lint
 
   test:
+    if: >-
+      inputs.manual || (
+        github.repository == 'jurplel/install-qt-action' && (
+          github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name ||
+          github.event.pull_request.user.login == 'dependabot[bot]'
+        )
+      )
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Discussion: https://github.com/jurplel/install-qt-action/issues/314#issuecomment-4212397220. Let's save time and energy for future people.

This PR will be merged in about one week. Anyone comes to review will be appreciated!

---

A screenshot of the user interactive part:

<img width="300" alt="Screenshot of the newly added input 'manual' for the 'workflow_dispatch' trigger event" src="https://github.com/user-attachments/assets/ba9e837d-515a-4ec4-9370-2668c6635d77" />

<p>

The result of that block of statements:

- Manual CI runs will always be performed in any repositories.
- In "jurplel/install-qt-action":
  - Any commits in any branches will trigger CI.
  - Any foreign PRs will trigger CI.
  - `dependabot[bot]` [^bot] will trigger CI even if the bot creates "native", "local", or "domestic" PRs.

</p>

Regarding the license [^rclone-license-mit] :

```
The input "manual" and its usage are based on the "rclone/rclone" project.
https://github.com/rclone/rclone/blob/c1f5df209024c79028c98134b703b31d599befac/.github/workflows/build.yml#L24
Copyright (C) 2012 by Nick Craig-Wood http://www.craig-wood.com/nick/. Licensed under MIT.

```

[^bot]: https://github.com/apps/dependabot
[^rclone-license-mit]: https://github.com/rclone/rclone/blob/c1f5df209024c79028c98134b703b31d599befac/COPYING