### PR TITLE
CI: Try limiting the max duration of workflow runs

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   lint:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -24,6 +25,7 @@ jobs:
           npm run lint
 
   test:
+    timeout-minutes: 30
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Discussion: https://github.com/jurplel/install-qt-action/issues/314#issuecomment-4209476634

Result of the test on Apr 24, 2026:

- CI (lint + test):
  - cache-missed: 22m 49s
  - cache-hit:    16m 45s
- CI-android (test):
  - cache-missed: 9m 58s
  - cache-hit:    8m 1s

Will merge in one day.

---

Thanks to @xavier2k6 and @pcolby for their observation.