### PR TITLE
CI: Remove QTBUG-117225 workaround due to new XCode and Qt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -155,17 +155,6 @@ jobs:
           # Check that QT_ROOT_DIR contains a qmake of some kind
           ls "${QT_ROOT_DIR}/bin/" | grep qmake
 
-      - name: Switch macOS Xcode version with older Qt versions
-        if: ${{ matrix.qt.version && startsWith(matrix.os, 'macos-13') }}
-        shell: pwsh
-        env:
-          QT_VERSION: ${{ matrix.qt.version }}
-        run: |
-          if ([version]$env:QT_VERSION -lt [version]'6.5.3') {
-            # Workaround for QTBUG-117225
-            sudo xcode-select --switch /Applications/Xcode_14.3.1.app
-          }
-
       - name: Configure test project on windows
         if: ${{ matrix.qt.version && startsWith(matrix.os, 'windows') && !matrix.skip-test-project }}
         env:


### PR DESCRIPTION
Discussion: https://github.com/jurplel/install-qt-action/issues/314#issuecomment-4274402557

Commit message:

> In current GitHub Actions runners, none of them has XCode 14 installed, so this workaround does not help:
> - https://github.com/actions/runner-images/blob/373741ffc0b04c5d6e16a2dd7bea589945f0253a/images/macos/macos-14-Readme.md#xcode
> - https://github.com/actions/runner-images/blob/373741ffc0b04c5d6e16a2dd7bea589945f0253a/images/macos/macos-15-Readme.md#xcode
> - https://github.com/actions/runner-images/blob/373741ffc0b04c5d6e16a2dd7bea589945f0253a/images/macos/macos-26-Readme.md#xcode
> 
> Per https://qt-project.atlassian.net/browse/QTBUG-117225, newer Qt (5.15.16, 6.5.3, and 6.6.0) should work fine, so we should be safe.
> 
> The removed workaround was from 99c242a43413cf86f4c2a3eceb77736a39af9505 .

This PR will be merged immediately.