### PR TITLE
chore: delete the useless top-level "package-lock.json"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "install-qt-action",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
That file was introduced in commit b47881db4e4c0a543d66e3e575f47fd495d779a8.