### PR TITLE
Add stacktrace with source line numbers for errors

### DIFF
--- a/action/package-lock.json
+++ b/action/package-lock.json
@@ -13,7 +13,8 @@
         "@actions/core": "^1.10.1",
         "@actions/exec": "^1.1.1",
         "compare-versions": "^3.6.0",
-        "glob": "^7.0.0"
+        "glob": "^7.0.0",
+        "source-map-support": "^0.5.21"
       },
       "devDependencies": {
         "@types/glob": "^7.2.0",
@@ -877,6 +878,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -2222,6 +2229,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3110,6 +3136,11 @@
       "requires": {
         "fill-range": "^7.1.1"
       }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
     },
     "call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -4050,6 +4081,20 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+    },
+    "source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
     },
     "strip-ansi": {
       "version": "6.0.1",

--- a/action/package.json
+++ b/action/package.json
@@ -20,7 +20,8 @@
     "@actions/core": "^1.10.1",
     "@actions/exec": "^1.1.1",
     "compare-versions": "^3.6.0",
-    "glob": "^7.0.0"
+    "glob": "^7.0.0",
+    "source-map-support": "^0.5.21"
   },
   "devDependencies": {
     "@types/glob": "^7.2.0",

--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -10,6 +10,7 @@ import { exec, getExecOutput } from "@actions/exec";
 
 import * as glob from "glob";
 import { compare, CompareOperator } from "compare-versions";
+import "source-map-support/register";
 
 const compareVersions = (v1: string, op: CompareOperator, v2: string): boolean => {
   return compare(v1, v2, op);
@@ -531,7 +532,7 @@ const run = async (): Promise<void> => {
 void run()
   .catch((err) => {
     if (err instanceof Error) {
-      core.setFailed(err);
+      core.setFailed(err.stack ?? err);
     } else {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       core.setFailed(`unknown error: ${err}`);

--- a/action/tsconfig.json
+++ b/action/tsconfig.json
@@ -46,14 +46,14 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
     // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */


### PR DESCRIPTION
## For avoiding possible toolchain attack:

The publication date of source-map-support v0.5.21: 2021-11-19T11:02:57.258Z 

See https://www.npmjs.com/package/source-map-support/v/0.5.21

## Test

Before:

```
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-python@v6' (SHA:a309ff8b426b58ec0e2a45f0f869d46889d02405)
Run ./
Run actions/setup-python@v6
Installed versions
Run ./action
Error: Error: Invalid argument not valid semver ('>6.8.3' received)

```

After:

```
Prepare all required actions
Getting action download info
Download action repository 'actions/setup-python@v6' (SHA:a309ff8b426b58ec0e2a45f0f869d46889d02405)
Run ./
Run actions/setup-python@v6
Installed versions
Run ./action
Error: Error: Invalid argument not valid semver ('>6.8.3' received)
    at validate (.../action/node_modules/compare-versions/index.js:36:13)
    at Array.forEach (<anonymous>)
    at compareVersions (.../action/node_modules/compare-versions/index.js:41:14)
    at compareVersions.compare (.../action/node_modules/compare-versions/index.js:110:15)
    at compareVersions (.../action/src/main.ts:16:17)
    at .../action/src/main.ts:369:11
    at Generator.next (<anonymous>)
    at .../action/lib/main.js:31:71
    at new Promise (<anonymous>)
    at __awaiter (.../action/lib/main.js:27:12)

```

These stack trace lines, especially `src/main.ts` ones may help us debug various issues.