### PR TITLE
Output cache key after saving cache for log inspection

### DIFF
--- a/action/src/main.ts
+++ b/action/src/main.ts
@@ -482,7 +482,7 @@ const run = async (): Promise<void> => {
   // Save automatic cache
   if (!internalCacheHit && inputs.cache) {
     const cacheId = await cache.saveCache([inputs.dir], inputs.cacheKey);
-    core.info(`Automatic cache saved with id ${cacheId}`);
+    core.info(`Automatic cache saved with key "${inputs.cacheKey}", cache id is "${cacheId}"`);
   }
 
   // Add tools to path


### PR DESCRIPTION
GitHub and `cache.restoreCache()` won't output the ID, so showing the ID only makes no sense.

https://github.com/jurplel/install-qt-action/blob/f818799bc997d374a9004ef94d076240964b9aec/action/src/main.ts#L385-L395

Before:

```
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/.../... --files-from manifest.txt --use-compress-program zstdmt
Sent ... of ... (...%), ... MBs/sec
Automatic cache saved with id 0000000000

```

After:

```
/usr/bin/tar --posix -cf cache.tzst --exclude cache.tzst -P -C /home/runner/work/.../... --files-from manifest.txt --use-compress-program zstdmt
Sent ... of ... (...%), ... MBs/sec
Automatic cache saved with key "install-qt-action-linux-6.17.0-1018-azure-desktop-6.8.3-/home/runner/work/.../Qt-==1.1.*-==3.3.*", cache id is "0000000000"

```

Then users will be able to inspect if the expected cache is used by subsequent runs:

```
Cache hit for: install-qt-action-linux-6.17.0-1018-azure-desktop-6.8.3-/home/runner/work/.../Qt-==1.1.*-==3.3.*
Received ... of ... (...%), ... MBs/sec
Cache Size: ~... MB (... B)
/usr/bin/tar -xf /home/runner/work/_temp/.../cache.tzst -P -C /home/runner/work/.../... --use-compress-program unzstd
Cache restored successfully
Automatic cache hit with key "install-qt-action-linux-6.17.0-1018-azure-desktop-6.8.3-/home/runner/work/.../Qt-==1.1.*-==3.3.*"

```

.