### PR TITLE
Update default Qt version and hint+examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in SimpleSpec version numbers, for example `6.2.*`.
 
-Default: `6.8.3` (Last Qt 6 LTS)
+Default: `6.8.*` (Latest Qt 6 LTS)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -90,7 +90,7 @@ Example:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.3'
+        version: '6.8.*'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
         use-official: true
@@ -298,7 +298,7 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.3'
+        version: '6.8.*'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.3"
+    default: "6.8.*"
   host:
     description: Host platform
   target:

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.3"
+    default: "6.8.*"
   host:
     description: Host platform
   target:


### PR DESCRIPTION
Connected to https://github.com/jurplel/install-qt-action/pull/335 & https://github.com/jurplel/install-qt-action/issues/304

Updating the default Qt version to automatically include patch releases for the latest LTS.
Examples in README are changed as well.