### PR TITLE
fix: workaround for Bad7zFile from aqtinstall by using py7zr v1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Default: `==3.3.*`
 ### `py7zrversion`
 Version of py7zr in the same style as the aqtversion and intended to be used for the same purpose.
 
-Default: `==1.1.*`
+Default: `==1.1.0`
 
 ### `extra`
 This input can be used to append arguments to the end of the aqtinstall command for any special purpose.

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,7 @@ inputs:
     default: ==3.3.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==1.1.*
+    default: ==1.1.0  # was "==1.1.*", use an older version as a workaround for Bad7zFile on Windows. Cache invalidation let us find this upstream bug.
   extra:
     description: Any extra arguments to append to the back
   source:


### PR DESCRIPTION
Workaround for issue #344. From https://github.com/miurahr/aqtinstall/issues/995#issuecomment-3818929270. Discovered in PR #335.

Remember to change the version to `py7zr>=1.fixed.version` then.