### PR TITLE
Use GitHub Actions CI infrastructure to build and make releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ concurrency:
   cancel-in-progress: false
 
 env:
+  # This is not the same as "github.ref_name" that's the branch specified in the popup
+  #   after clicking the "Run workflow" button for "workflow_dispatch" workflows.
   SOURCE_BRANCH: master
 
 jobs:
@@ -174,6 +176,9 @@ jobs:
 
           git tag "$TAG"
 
+      # Search "x-access-token" in:
+      # - Authenticating as a GitHub App installation - GitHub Docs
+      #   https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-as-a-github-app-installation
       - name: Update branch and push the tag
         shell: bash
         env:
@@ -182,7 +187,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          set -eu  # no "set -x"!
+          set -eu  # no "set -x", otherwise not safe for tokens.
 
           git push --atomic "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" \
             "HEAD:$TARGET_BRANCH" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
         run: |
-          set -eux
+          set -eu  # no "set -x"!
 
           git push --atomic "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" \
             "HEAD:$TARGET_BRANCH" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,8 @@
 name: Release
 
-# In this script, I prefer hand-made shell scripts to concrete
+# Trigger this workflow on GitHub Web UI. If GitHub is down, we don't need to do anything.
+
+# In bash shell scripts of this workflow, I prefer hand-made shell scripts to concrete
 #   actions, especially 3rd-party ones, to reveal the actual logic.
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           fetch-depth: 0  # all branches and tags.
           persist-credentials: false  # otherwise malicious or unexpected git-pushes may happen.
-          ref: ${{ steps.info.outputs.target_branch }}
+          ref: ${{ env.SOURCE_BRANCH }}  # the target branch may not exist for now, but the source one must be there.
 
       - name: Refuse to overwrite existing tag
         shell: bash
@@ -73,9 +73,24 @@ jobs:
             exit 1
           fi
 
+      - name: Check if the target branch '${{ steps.info.outputs.target_branch }}' exists
+        id: check_target_branch
+        shell: bash
+        env:
+          TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
+        run: |
+          set -eux
+
+          if git show-branch "$TARGET_BRANCH"; then
+            echo "existing=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "existing=false" >> "$GITHUB_OUTPUT"
+          fi
+
       # Merge all commits from the source branch since the previous merge point.
       # The source branch itself remains untouched.
-      - name: Merge branch '${{ env.SOURCE_BRANCH }}'
+      - name: Merge branch '${{ env.SOURCE_BRANCH }}' if branch '${{ steps.info.outputs.target_branch }}' exists
+        if: ${{ steps.check_target_branch.outputs.existing == 'true' }}
         shell: bash
         env:
           SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
@@ -83,6 +98,8 @@ jobs:
           TAG: ${{ steps.info.outputs.tag }}
         run: |
           set -eux
+
+          git switch "$TARGET_BRANCH"
 
           # Record the current commit hash.
           existing_commit="$(git rev-parse HEAD)"
@@ -99,6 +116,16 @@ jobs:
             exit 1
           fi
 
+      - name: Create branch '${{ steps.info.outputs.target_branch }}' for new major versions
+        if: ${{ steps.check_target_branch.outputs.existing == 'false' }}
+        shell: bash
+        env:
+          TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
+        run: |
+          set -eux
+
+          git switch -c "$TARGET_BRANCH"
+
       # Do NOT cache anything.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -107,14 +134,17 @@ jobs:
       - name: Remove old Node.js files, recreate new ones, and commit them if they are changed
         shell: bash
         env:
+          DIST_EXISTING: ${{ steps.check_target_branch.outputs.existing }}
           TAG: ${{ steps.info.outputs.tag }}
         run: |
           set -eux
 
           cd action
 
-          rm ./lib/main.js
-          rm -r ./node_modules
+          if [[ "$DIST_EXISTING" == 'true' ]]; then
+            rm ./lib/main.js
+            rm -r ./node_modules
+          fi
 
           npm ci
           npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
     inputs:
       version:
         description: |
-          In the form of "vX.Y.Z". There should already be a "vX" branch.
+          In the form of "vX.Y.Z". Existing "vX" branches will be updated; missing "vX" branches will be created.
         required: true
         type: string
 
@@ -143,6 +143,7 @@ jobs:
 
           cd action
 
+          # Let it crash if files to be deleted do not exist.
           if [[ "$DIST_EXISTING" == 'true' ]]; then
             rm ./lib/main.js
             rm -r ./node_modules

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,8 +123,14 @@ jobs:
           git add ./lib/main.js
           git add --force ./node_modules
 
+          untracked_files="$(git ls-files --others --exclude-standard)"
+          if [[ -n "$untracked_files" ]]; then
+            echo "Unexpected untracked files detected: $untracked_files"
+            exit 1
+          fi
+
           if ! git diff --exit-code; then
-            echo 'Unexpected file changes detected.'
+            echo 'Unexpected tracked file changes detected.'
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,151 @@
+name: Release
+
+# In this script, I prefer hand-made shell scripts than concreate
+#   actions, especially 3rd ones, to reveal the acutal logic.
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: |
+          In the form of "vX.Y.Z". There should already be a "vX" branch.
+        required: true
+        type: string
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  SOURCE_BRANCH: master
+
+jobs:
+  release:
+    name: Release ${{ inputs.version }}
+    permissions:
+      contents: write
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Extract version information
+        id: info
+        shell: bash
+        run: |
+          set -eux
+
+          if ! [[ '${{ inputs.version }}' =~ ^v(([0-9]+)\.[0-9]+\.[0-9]+)$ ]]; then
+            exit 1
+          fi
+          full_version="${BASH_REMATCH[1]}"
+          major_version="${BASH_REMATCH[2]}"
+
+          echo "tag=v$full_version" >> "$GITHUB_OUTPUT"
+          echo "target_branch=v$major_version" >> "$GITHUB_OUTPUT"
+
+      # Ref:
+      # - No documentation for git email and username causes actions to use 41898282+github-actions[bot]@users.noreply.github.com
+      #   https://github.com/orgs/community/discussions/119597
+      - name: Configure Git identity
+        shell: bash
+        run: |
+          set -eux
+
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0  # all branches and tags.
+          ref: ${{ steps.info.outputs.target_branch }}
+
+      - name: Refuse to overwrite existing tag
+        shell: bash
+        run: |
+          set -eux
+
+          version='${{ steps.info.outputs.tag }}'
+          if git rev-parse "$version" >/dev/null 2>&1; then
+            echo "Tag $version already exists."
+            exit 1
+          fi
+
+      - name: Merge branch '${{ env.SOURCE_BRANCH }}'
+        shell: bash
+        run: |
+          set -eux
+
+          # Merge all commits from the source branch since the previous merge point.
+          # The source branch itself remains untouched.
+          source='${{ env.SOURCE_BRANCH }}'
+          target='${{ steps.info.outputs.target_branch }}'
+          # Record the current commit hash.
+          existing_commit="$(git rev-parse HEAD)"
+
+          git merge --no-ff "origin/$source" -m "Merge branch '$source' into $target for ${{ steps.info.outputs.tag }}"
+
+          # The git-merge exits with "Already up to date." and code 0, so we have to check it manually.
+          # This should not happen if this workflow is already in the source branch and it is triggered
+          # at the source branch. Since we're using "workflow_dispatch", you may need to read:
+          # - Provide clarity in documentation on "Use workflow from" Dropdown when running Manual Workflow
+          #   https://github.com/orgs/community/discussions/112371
+          if [[ "$existing_commit" == "$(git rev-parse HEAD)" ]]; then
+            echo "Source branch $source has not been updated since the last commit on branch $target."
+            exit 1
+          fi
+
+      # Do NOT cache anything.
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: 24
+
+      - name: Remove old Node.js files, recreate new ones, and commit them if they are changed
+        shell: bash
+        run: |
+          set -eux
+
+          cd action
+
+          rm ./lib/main.js
+          rm -r ./node_modules
+
+          npm ci
+          npm run build
+          npm prune --omit=dev
+
+          git add ./lib/main.js
+          git add --force ./node_modules
+
+          if ! git diff --exit-code; then
+            echo 'Unexpected file changes detected.'
+            exit 1
+          fi
+
+          if ! git diff --cached --exit-code --quiet; then
+            git commit -m 'Build ${{ steps.info.outputs.tag }}'
+          fi
+
+          git tag '${{ steps.info.outputs.tag }}'
+
+      - name: Update branch and push the tag
+        shell: bash
+        run: |
+          set -eux
+
+          git push origin \
+            HEAD:'${{ steps.info.outputs.target_branch }}' \
+            refs/tags/'${{ steps.info.outputs.tag }}'
+
+      - name: Create tag and release with generated notes
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eux
+
+          # Use "--verify-tag" to make sure GitHub can see the tag.
+          gh release create '${{ steps.info.outputs.tag }}' \
+            --title 'install-qt-action ${{ steps.info.outputs.tag }}' \
+            --target '${{ steps.info.outputs.target_branch }}' \
+            --generate-notes \
+            --latest \
+            --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
-# In this script, I prefer hand-made shell scripts than concreate
-#   actions, especially 3rd ones, to reveal the acutal logic.
+# In this script, I prefer hand-made shell scripts to concrete
+#   actions, especially 3rd-party ones, to reveal the actual logic.
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,7 @@ jobs:
         run: |
           set -eux
 
-          git switch "$TARGET_BRANCH"
+          git switch -c "$TARGET_BRANCH" --track "origin/$TARGET_BRANCH"
 
           # Record the current commit hash.
           existing_commit="$(git rev-parse HEAD)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
           TAG: ${{ steps.info.outputs.tag }}
           TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -eux
 
@@ -148,6 +148,7 @@ jobs:
             "HEAD:$TARGET_BRANCH" \
             "refs/tags/$TAG"
 
+      # If this step fails, we can manually release a new version on GitHub Web UI.
       - name: Create tag and release with generated notes
         shell: bash
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,11 +57,11 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
+      # The actual checked-out branch "github.ref_name" is not important.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0  # all branches and tags.
           persist-credentials: false  # otherwise malicious or unexpected git-pushes may happen.
-          ref: ${{ env.SOURCE_BRANCH }}  # the target branch may not exist for now, but the source one must be there.
 
       - name: Refuse to overwrite existing tag
         shell: bash
@@ -122,11 +122,12 @@ jobs:
         if: ${{ steps.check_target_branch.outputs.existing == 'false' }}
         shell: bash
         env:
+          SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
           TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
         run: |
           set -eux
 
-          git switch -c "$TARGET_BRANCH"
+          git switch --no-track -c "$TARGET_BRANCH" "origin/$SOURCE_BRANCH"
 
       # Do NOT cache anything.
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
         run: |
           set -eux
 
-          git push origin \
+          git push --atomic origin \
             HEAD:'${{ steps.info.outputs.target_branch }}' \
             refs/tags/'${{ steps.info.outputs.tag }}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0  # all branches and tags.
+          persist-credentials: false  # otherwise malicious or unexpected git-pushes may happen.
           ref: ${{ steps.info.outputs.target_branch }}
 
       - name: Refuse to overwrite existing tag
@@ -138,10 +139,12 @@ jobs:
         env:
           TAG: ${{ steps.info.outputs.tag }}
           TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ env.GITHUB_REPOSITORY }}
         run: |
           set -eux
 
-          git push --atomic origin \
+          git push --atomic "https://x-access-token:${GH_TOKEN}@github.com/${GH_REPO}.git" \
             "HEAD:$TARGET_BRANCH" \
             "refs/tags/$TAG"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           set -eux
 
-          if git show-branch "$TARGET_BRANCH"; then
+          if git show-branch "origin/$TARGET_BRANCH"; then
             echo "existing=true" >> "$GITHUB_OUTPUT"
           else
             echo "existing=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,10 +30,12 @@ jobs:
       - name: Extract version information
         id: info
         shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
         run: |
           set -eux
 
-          if ! [[ '${{ inputs.version }}' =~ ^v(([0-9]+)\.[0-9]+\.[0-9]+)$ ]]; then
+          if ! [[ "$VERSION" =~ ^v(([0-9]+)\.[0-9]+\.[0-9]+)$ ]]; then
             exit 1
           fi
           full_version="${BASH_REMATCH[1]}"
@@ -60,28 +62,31 @@ jobs:
 
       - name: Refuse to overwrite existing tag
         shell: bash
+        env:
+          TAG: ${{ steps.info.outputs.tag }}
         run: |
           set -eux
 
-          version='${{ steps.info.outputs.tag }}'
-          if git rev-parse --verify "refs/tags/$version" >/dev/null 2>&1; then
-            echo "Tag $version already exists."
+          if git rev-parse --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists."
             exit 1
           fi
 
+      # Merge all commits from the source branch since the previous merge point.
+      # The source branch itself remains untouched.
       - name: Merge branch '${{ env.SOURCE_BRANCH }}'
         shell: bash
+        env:
+          SOURCE_BRANCH: ${{ env.SOURCE_BRANCH }}
+          TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
+          TAG: ${{ steps.info.outputs.tag }}
         run: |
           set -eux
 
-          # Merge all commits from the source branch since the previous merge point.
-          # The source branch itself remains untouched.
-          source='${{ env.SOURCE_BRANCH }}'
-          target='${{ steps.info.outputs.target_branch }}'
           # Record the current commit hash.
           existing_commit="$(git rev-parse HEAD)"
 
-          git merge --no-ff "origin/$source" -m "Merge branch '$source' into $target for ${{ steps.info.outputs.tag }}"
+          git merge --no-ff "origin/$SOURCE_BRANCH" -m "Merge branch '$SOURCE_BRANCH' into $TARGET_BRANCH for $TAG"
 
           # The git-merge exits with "Already up to date." and code 0, so we have to check it manually.
           # This should not happen if this workflow is already in the source branch and it is triggered
@@ -89,7 +94,7 @@ jobs:
           # - Provide clarity in documentation on "Use workflow from" Dropdown when running Manual Workflow
           #   https://github.com/orgs/community/discussions/112371
           if [[ "$existing_commit" == "$(git rev-parse HEAD)" ]]; then
-            echo "Source branch $source has not been updated since the last commit on branch $target."
+            echo "Source branch $SOURCE_BRANCH has not been updated since the last commit on branch $TARGET_BRANCH."
             exit 1
           fi
 
@@ -100,6 +105,8 @@ jobs:
 
       - name: Remove old Node.js files, recreate new ones, and commit them if they are changed
         shell: bash
+        env:
+          TAG: ${{ steps.info.outputs.tag }}
         run: |
           set -eux
 
@@ -121,31 +128,36 @@ jobs:
           fi
 
           if ! git diff --cached --exit-code --quiet; then
-            git commit -m 'Build ${{ steps.info.outputs.tag }}'
+            git commit -m "Build $TAG"
           fi
 
-          git tag '${{ steps.info.outputs.tag }}'
+          git tag "$TAG"
 
       - name: Update branch and push the tag
         shell: bash
+        env:
+          TAG: ${{ steps.info.outputs.tag }}
+          TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
         run: |
           set -eux
 
           git push --atomic origin \
-            HEAD:'${{ steps.info.outputs.target_branch }}' \
-            refs/tags/'${{ steps.info.outputs.tag }}'
+            "HEAD:$TARGET_BRANCH" \
+            "refs/tags/$TAG"
 
       - name: Create tag and release with generated notes
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.info.outputs.tag }}
+          TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
         run: |
           set -eux
 
           # Use "--verify-tag" to make sure GitHub can see the tag.
-          gh release create '${{ steps.info.outputs.tag }}' \
-            --title 'install-qt-action ${{ steps.info.outputs.tag }}' \
-            --target '${{ steps.info.outputs.target_branch }}' \
+          gh release create "$TAG" \
+            --title "install-qt-action $TAG" \
+            --target "$TARGET_BRANCH" \
             --generate-notes \
             --latest \
             --verify-tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
           set -eux
 
           version='${{ steps.info.outputs.tag }}'
-          if git rev-parse "$version" >/dev/null 2>&1; then
+          if git rev-parse --verify "refs/tags/$version" >/dev/null 2>&1; then
             echo "Tag $version already exists."
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 # Trigger this workflow on GitHub Web UI. If GitHub is down, we don't need to do anything.
 
 # In bash shell scripts of this workflow, I prefer hand-made shell scripts to concrete
-#   actions, especially 3rd-party ones, to reveal the actual logic.
+# actions, especially 3rd-party ones, to reveal the actual logic.
 
 on:
   workflow_dispatch:
@@ -20,7 +20,7 @@ concurrency:
 
 env:
   # This is not the same as "github.ref_name" that's the branch specified in the popup
-  #   after clicking the "Run workflow" button for "workflow_dispatch" workflows.
+  # after clicking the "Run workflow" button for "workflow_dispatch" workflows.
   SOURCE_BRANCH: master
 
 jobs:


### PR DESCRIPTION
Points:

- The creation of new releases is triggered by manual operations on GitHub Web UI.
- Always use `set -eux`.
- Use `npm ci` only.
- `41898282+github-actions[bot]@users.noreply.github.com`.
- Use `git diff ... --exit-code` to detect both expected and unexpected file changes.

Why:

- Less supply-chain attacks.

You may ask:

- Q: Why no signed commit?
  A: It will be complicated and won't give any benefit. Since the secret can be accessed by the workflow, attackers who can alter the workflow can also make signed commits.

.