### PR TITLE
Bypass protection by using "secrets.IQTA_RELEASE_PAT" during release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -190,7 +190,17 @@ jobs:
         env:
           TAG: ${{ steps.info.outputs.tag }}
           TARGET_BRANCH: ${{ steps.info.outputs.target_branch }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          # "PAT" stands for "Personal Access Tokens". To bypass branches/tags protection,
+          # only perm "Contents: write" is enough.
+          # Don't forget to add "Write (Roles)" into the "Bypass list" of corresponding rulesets.
+          # Adding "Write (Roles)" will essentially disable the safety net in response to human's
+          # error, so it's recommended to remove the bypass item after a successful release ASAP.
+          # "secrets.GITHUB_TOKEN" can be used here if no protection rule applied. Read:
+          # - [Feature Request] Allow github actions to bypass branch protection rules in certain specific circumstances
+          #   https://github.com/orgs/community/discussions/13836
+          GH_TOKEN: ${{ secrets.IQTA_RELEASE_PAT }}
+
           GH_REPO: ${{ github.repository }}
         run: |
           set -eu  # no "set -x", otherwise not safe for tokens.


### PR DESCRIPTION
Commit message:

```
Bypass protection by using "secrets.IQTA_RELEASE_PAT" during release 

Security is hard.

```

Please read the code to learn the steps.

I'll merge this instantly.