### PR TITLE
README: Harmonize arch label around bit-ness for Windows x64 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This is the target architecture that your program will be built for.
 You can find a full list of architectures easily by using [this awesome website](https://ddalcino.github.io/aqt-list-server/).
 
 Default: Depends on OS, Qt version and CPU architecture:
-- Windows (x86)
+- Windows (x64)
   - Qt <5.6: `win64_msvc2013_64`
   - Qt >=5.6,<5.9: `win64_msvc2015_64`
   - Qt >=5.9,<5.15: `win64_msvc2017_64`


### PR DESCRIPTION
Related #347

As `ARM64` is used over general `ARM` in the docs,
it should be `x64` over general `x86` to stress both are 64 bit.

*(Actually not sure if an addition for Android is needed, and which would be appropriate)*