### PR TITLE
Pin actions to commit hash

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -51,9 +51,9 @@ jobs:
             example-modules:  qtsensors
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -47,8 +47,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: npm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: npm
@@ -141,9 +141,9 @@ jobs:
 
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 24
           cache: npm

--- a/action.yml
+++ b/action.yml
@@ -94,7 +94,7 @@ runs:
   steps:
   - name: Setup Python
     if: ${{ inputs.setup-python  == 'true' }}
-    uses: actions/setup-python@v6
+    uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
     with:
       python-version: '>=3.10.0'
 


### PR DESCRIPTION
GitHub has an option for repositories to require actions to be pinned to full commit hashes (e.g. https://github.com/jurplel/install-qt-action/settings/actions -> "Require actions to be pinned to a full-length commit SHA").

The setting also requires composite actions such as this one to pin references. This PR pins the actions. I also included the workflows from this repository. If you're using Dependabot to update actions, then it will automatically pin updated actions and update the comment.

I used [`zizmor`](https://docs.zizmor.sh) to do this - it's quite helpful for this.