### PR TITLE
Call internal action with self-repository syntax ($) for full-length SHA and hack the path before running tests

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Use local built internal action (hack)
         run: |
           sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
-          diff -u action.yml.bak action.yml
+          diff -u action.yml.bak action.yml || true
           git status --porcelain
         shell: bash
 

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -68,6 +68,14 @@ jobs:
           cd action
           npm run build
 
+      # See the root "action.yml" file.
+      - name: Use local built internal action (hack)
+        run: |
+          sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
+          diff -u action.yml.bak action.yml
+          git status --porcelain
+        shell: bash
+
       - name: Install Qt
         uses: ./
         with:

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Use local built internal action (hack)
         run: |
           sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
-          diff -u action.yml.bak action.yml
+          diff -u action.yml.bak action.yml || true
           git status --porcelain
         shell: bash
 

--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -59,6 +59,14 @@ jobs:
           npm run build
         shell: bash
 
+      # See the root "action.yml" file.
+      - name: Use local built internal action (hack)
+        run: |
+          sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
+          diff -u action.yml.bak action.yml
+          git status --porcelain
+        shell: bash
+
       - name: Prologue - purge existing cache entries
         run: |
           set -e; set -u;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,6 +158,14 @@ jobs:
           cd action
           npm run build
 
+      # See the root "action.yml" file.
+      - name: Use local built internal action (hack)
+        run: |
+          sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
+          diff -u action.yml.bak action.yml
+          git status --porcelain
+        shell: bash
+
       - name: Install Qt with options and default aqtversion
         if: ${{ !matrix.aqtversion && matrix.qt.version }}
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,7 +162,7 @@ jobs:
       - name: Use local built internal action (hack)
         run: |
           sed -i.bak 's|uses: $/action|uses: ./action|' action.yml
-          diff -u action.yml.bak action.yml
+          diff -u action.yml.bak action.yml || true
           git status --porcelain
         shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -99,6 +99,11 @@ runs:
       python-version: '>=3.10.0'
 
   - name: Setup and run aqtinstall
+    # The dollar sign:
+    # - Reference same-repository actions with self-repository syntax - GitHub Changelog
+    #   https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/
+    # To run tests in this repository, we need to replace "$/action" with "./action"
+    # because a "lib/main.js" file is expected, but we don't have one in non-tagging branches.
     uses: $/action
     with:
       dir: ${{ inputs.dir }}

--- a/action.yml
+++ b/action.yml
@@ -99,7 +99,7 @@ runs:
       python-version: '>=3.10.0'
 
   - name: Setup and run aqtinstall
-    uses: ./action
+    uses: $/action
     with:
       dir: ${{ inputs.dir }}
       version: ${{ inputs.version }}


### PR DESCRIPTION
Follows #360, helps #322.

<br>

Credit goes to @jdpurcell.

Source: 
  - https://github.com/jurplel/install-qt-action/pull/360#issuecomment-5454183276
  - https://github.com/jdpurcell/install-qt-action/commit/6b4aef3c7d121445d0eda7f44227eae7d936a08f

Docs: Reference same-repository actions with self-repository syntax - GitHub Changelog - https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/ (July 30, 2026)
