### PR TITLE
Show error message for wrong action usage on non-tagging branches

### DIFF
--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -53,11 +53,15 @@ jobs:
           node-version: 24
           cache: npm
           cache-dependency-path: action/
+
       - run: |
           cd action
           npm ci || npm install
-          npm run build
         shell: bash
+
+      - run: |
+          cd action
+          npm run build
 
       # See the root "action.yml" file.
       - name: Use local built internal action (hack)

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,27 @@ inputs:
 runs:
   using: "composite"
   steps:
+  - name: Check the existence of built JavaScript action
+    shell: python  # we must have a default Python here.
+    working-directory: ${{ github.action_path }}  # $GITHUB_ACTION_PATH; composite actions only.
+    run: |
+      from pathlib import Path
+
+      if Path('./action/lib/main.js').exists():
+          exit(0)
+
+      message = ' '.join((
+        'This TypeScript action cannot be used before building within Node.js environment.',
+        'Maybe you are currently using non-tagging branches, for example, the "master" branch.',
+        'Only v* branches have built JavaScript action file.',
+        'If you would like to test unreleased changes, please refer to the CI workflows',
+        'in our repository: https://github.com/jurplel/install-qt-action .',
+        'Exiting...',
+      ))
+      print(f'::error title=Action not built::{message}')
+
+      exit(1)
+
   - name: Setup Python
     if: ${{ inputs.setup-python  == 'true' }}
     uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0


### PR DESCRIPTION
Commit message:

```
And make the building scripts consistent across different CI workflow files.

Show error message for wrong action usage on non-tagging branches

```

Screenshot of the error message: 

<img height="300" alt="Screenshot of a failed run" src="https://github.com/user-attachments/assets/3f597db9-25e9-45cd-8319-1bdadfa573d9" />

Tests, tags, and tagging branches will not be affected.