### PR TITLE
Sync internal metadata file with the top-level one; format comments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,8 @@ inputs:
     default: ==3.3.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==1.1.0  # was "==1.1.*", use an older version as a workaround for Bad7zFile on Windows. Cache invalidation let us find this upstream bug.
+    default: ==1.1.0  # was "==1.1.*"
+    # Use an older version as a workaround for Bad7zFile on Windows. Cache invalidation let us find this upstream bug.
   extra:
     description: Any extra arguments to append to the back
   source:

--- a/action/action.yml
+++ b/action/action.yml
@@ -55,7 +55,8 @@ inputs:
     default: ==3.3.*
   py7zrversion:
     description: Version of py7zr to use in case of issues
-    default: ==1.1.*
+    default: ==1.1.0  # was "==1.1.*"
+    # Use an older version as a workaround for Bad7zFile on Windows. Cache invalidation let us find this upstream bug.
   extra:
     description: Any extra arguments to append to the back
   source:


### PR DESCRIPTION
COmmit message:

```
Sync internal metadata file with the top-level one; format comments

The difference between default values of "py7zrversion" is a bit risky.
Didn't notice this in commit b65977746981b1a72c0ff2c5ee317f835c6a292c .

```

Follows PR #345 (b65977746981b1a72c0ff2c5ee317f835c6a292c).
