### PR TITLE
Switch the default version back to "6.8.3" for best usability; Update comments about the choice of v6.8.3 in Cache-SimpleSpec test

### DIFF
--- a/.github/workflows/test-cache.yml
+++ b/.github/workflows/test-cache.yml
@@ -98,7 +98,7 @@ jobs:
           done
           echo "Done"
 
-      # - Qt is commercial-only LTS, so we can safely test "6.*.3" for released LTS.
+      # - Qt is commercial-only LTS, so we open-source license holders can safely test "6.8.3", the latest patch release.
       #
       # - Version specifications (the Spec class) § Reference — python-semanticversion latest documentation
       #   https://python-semanticversion.readthedocs.io/en/latest/reference.html#version-specifications-the-spec-class

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The desired version of Qt to install.
 
 You can also pass in [SimpleSpec version](https://pypi.org/project/semantic-version/#the-simplespec-scheme) ranges or use wildcards, for example `6.2.*` or `>=6.2.0,<6.5.0`. Beta releases will not be excluded if the version range is too large (e.g., `>=6.*.*`); you need to set ranges and wildcard patterns accordingly.
 
-Default: `6.8.*` (Latest Qt 6 LTS)
+Default: `6.8.3` (A tested Qt 6 LTS version for open-source licensed users)
 
 **Please note that for Linux builds, Qt 6+ requires Ubuntu 20.04 or later.**
 
@@ -90,7 +90,7 @@ Example:
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.*'
+        version: '6.8.3'
         target: 'desktop'
         arch: 'win64_msvc2022_64'
         use-official: true
@@ -298,7 +298,7 @@ Example value: `--external 7z`
     - name: Install Qt
       uses: jurplel/install-qt-action@v4
       with:
-        version: '6.8.*'
+        version: '6.8.3'
         host: 'windows'
         target: 'desktop'
         arch: 'win64_msvc2022_64'

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.*"
+    default: "6.8.3"
   host:
     description: Host platform
   target:

--- a/action/action.yml
+++ b/action/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: Directory to install Qt
   version:
     description: Version of Qt to install
-    default: "6.8.*"
+    default: "6.8.3"
   host:
     description: Host platform
   target:


### PR DESCRIPTION
I'm from https://github.com/jurplel/install-qt-action/issues/356#issuecomment-5638588986 .

> We really need to go back to the current good LTS version "6.8.3" ...

@tooomm, please have a look.